### PR TITLE
feat: track errors

### DIFF
--- a/ERRORS.md
+++ b/ERRORS.md
@@ -1,0 +1,7 @@
+# Common Biconomy error responses
+
+### code=UNPREDICTABLE_GAS_LIMIT:
+
+```
+{"timestamp":"{timestamp}","kind":"ERROR","system":"transactions-server","message":"Error: An error occurred trying to send the meta transaction. Response: {\"log\":\"Error while gas estimation with message cannot estimate gas; transaction may fail or may require manual gas limit [...] \\\\\\\"id\\\\\\\":{id},\\\\\\\"jsonrpc\\\\\\\":\\\\\\\"2.0\\\\\\\"}\\\",\\\"requestMethod\\\":\\\"POST\\\",\\\"url\\\":\\\"https://rpc-biconomy-mainnet.maticvigil.com/v1/{key}\\\"}, method=\\\"estimateGas\\\", transaction={\\\"from\\\":\\\"{{from}}\\\",\\\"to\\\":\\\"{to}\\\",\\\"data\\\":\\\"{data}\\\", code=UNPREDICTABLE_GAS_LIMIT, version=providers/5.4.0)\",\"flag\":417,\"code\":417}.\n
+```

--- a/ERRORS.md
+++ b/ERRORS.md
@@ -3,5 +3,9 @@
 ### code=UNPREDICTABLE_GAS_LIMIT:
 
 ```
-{"timestamp":"{timestamp}","kind":"ERROR","system":"transactions-server","message":"Error: An error occurred trying to send the meta transaction. Response: {\"log\":\"Error while gas estimation with message cannot estimate gas; transaction may fail or may require manual gas limit [...] \\\\\\\"id\\\\\\\":{id},\\\\\\\"jsonrpc\\\\\\\":\\\\\\\"2.0\\\\\\\"}\\\",\\\"requestMethod\\\":\\\"POST\\\",\\\"url\\\":\\\"https://rpc-biconomy-mainnet.maticvigil.com/v1/{key}\\\"}, method=\\\"estimateGas\\\", transaction={\\\"from\\\":\\\"{{from}}\\\",\\\"to\\\":\\\"{to}\\\",\\\"data\\\":\\\"{data}\\\", code=UNPREDICTABLE_GAS_LIMIT, version=providers/5.4.0)\",\"flag\":417,\"code\":417}.\n
+{"timestamp":"{timestamp}","kind":"ERROR","system":"transactions-server","message":"Error: An error occurred trying to send the meta transaction.
+Response: {\"log\":\"Error while gas estimation with message cannot estimate gas; transaction may fail or may require manual gas limit [...]
+\\\\\\\"id\\\\\\\":{id},\\\\\\\"jsonrpc\\\\\\\":\\\\\\\"2.0\\\\\\\"}\\\",\\\"requestMethod\\\":\\\"POST\\\",\\\"url\\\":\\\
+"https://rpc-biconomy-mainnet.maticvigil.com/v1/{key}\\\"}, method=\\\"estimateGas\\\", transaction={\\\"from\\\":\\\"{{from}}\\\",
+\\\"to\\\":\\\"{to}\\\",\\\"data\\\":\\\"{data}\\\", code=UNPREDICTABLE_GAS_LIMIT, version=providers/5.4.0)\",\"flag\":417,\"code\":417}.\n
 ```

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Server to relay meta-transactions.
 
+## Set up
+
+You'll need to check the `.env.example` file and create your own `.env` file. Some properties have defaults. Once you're done, you can run the project!
+
 # Run the project
 
 The server's only dependency is sqlite3 which needs to be initialized first.
@@ -9,13 +13,8 @@ The server's only dependency is sqlite3 which needs to be initialized first.
 ```bash
 npm install
 npm run migrate
-```
-
-After that you'll need to up check the `.env.example` file and create your own `.env` file. Some properties have defaults. Once you're done, you can run the project!
-
-```bash
 npm start # runs npm run build behind the scenes
-
+# or
 npm run start:watch # will watch for changes
 ```
 
@@ -32,3 +31,9 @@ You can also check this [`Playground`](https://web3playground.io/Qmd2WcPpBwM3NqB
 ### GET /transactions/:userAddress
 
 Returns the transactions an address relayed
+
+# Test
+
+```bash
+npm run test
+```

--- a/src/logic/transaction.ts
+++ b/src/logic/transaction.ts
@@ -47,7 +47,7 @@ export async function sendMetaTransaction(
       from: transactionData.from,
     }
     if (errorMessage.includes('UNPREDICTABLE_GAS_LIMIT')) {
-      // This error happens when the contract execution will fail
+      // This error happens when the contract execution will fail. See https://github.com/decentraland/transactions-server/blob/4bf7f6841b3a9d5933d325157acb0f190f9b574c/ERRORS.md
       metrics.increment(
         'dcl_error_cannot_estimate_gas_transactions_biconomy',
         errorPayload

--- a/src/logic/transaction.ts
+++ b/src/logic/transaction.ts
@@ -47,7 +47,7 @@ export async function sendMetaTransaction(
       from: transactionData.from,
     }
     if (errorMessage.includes('UNPREDICTABLE_GAS_LIMIT')) {
-      // This error happens when the contract execution will fail. See https://github.com/decentraland/transactions-server/blob/4bf7f6841b3a9d5933d325157acb0f190f9b574c/ERRORS.md
+      // This error happens when the contract execution will fail. See https://github.com/decentraland/transactions-server/blob/2e5d833f672a87a7acf0ff761f986421676c4ec9/ERRORS.md
       metrics.increment(
         'dcl_error_cannot_estimate_gas_transactions_biconomy',
         errorPayload

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -7,10 +7,17 @@ export const metricDeclarations = {
     type: IMetricsComponent.CounterType,
     labelNames: ['contract'],
   },
-  dcl_sent_amount_biconomy: {
-    help: 'Count transactions sent to BICONOMY',
+  dcl_error_cannot_estimate_gas_transactions_biconomy: {
+    help:
+      'Count errors of cannot estimate gas when trying to relay a transaction to BICONOMY',
     type: IMetricsComponent.CounterType,
-    labelNames: ['contract', 'amount'],
+    labelNames: ['contract', 'data', 'from'],
+  },
+  dcl_error_relay_transactions_biconomy: {
+    help:
+      'Count errors of BICONOMY Api when trying to relay a transaction to BICONOMY',
+    type: IMetricsComponent.CounterType,
+    labelNames: ['transactionData'],
   },
 }
 

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -17,7 +17,7 @@ export const metricDeclarations = {
     help:
       'Count errors of BICONOMY Api when trying to relay a transaction to BICONOMY',
     type: IMetricsComponent.CounterType,
-    labelNames: ['transactionData'],
+    labelNames: ['contract', 'data', 'from'],
   },
 }
 

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -8,14 +8,12 @@ export const metricDeclarations = {
     labelNames: ['contract'],
   },
   dcl_error_cannot_estimate_gas_transactions_biconomy: {
-    help:
-      'Count errors of cannot estimate gas when trying to relay a transaction to BICONOMY',
+    help: 'Count errors of cannot estimate gas when trying to relay a transaction to BICONOMY',
     type: IMetricsComponent.CounterType,
     labelNames: ['contract', 'data', 'from'],
   },
   dcl_error_relay_transactions_biconomy: {
-    help:
-      'Count errors of BICONOMY Api when trying to relay a transaction to BICONOMY',
+    help: 'Count errors of BICONOMY Api when trying to relay a transaction to BICONOMY',
     type: IMetricsComponent.CounterType,
     labelNames: ['contract', 'data', 'from'],
   },

--- a/test/components.ts
+++ b/test/components.ts
@@ -2,20 +2,17 @@ import { createDotEnvConfigComponent } from '@well-known-components/env-config-p
 import {
   createServerComponent,
   createStatusCheckComponent,
-  IFetchComponent,
 } from '@well-known-components/http-server'
 import { createLogComponent } from '@well-known-components/logger'
 import { createMetricsComponent } from '@well-known-components/metrics'
 import { metricDeclarations } from '../src/metrics'
 import { createDatabaseComponent } from '../src/ports/database/component'
 import {
-  createFetchComponent,
   createTestFetchComponent,
 } from '../src/ports/fetcher'
-import { AppComponents, GlobalContext, TestComponents } from '../src/types'
+import { GlobalContext, TestComponents } from '../src/types'
 import { main } from '../src/service'
 import { createRunner } from '@well-known-components/test-helpers'
-import { RequestInfo, RequestInit } from 'node-fetch'
 
 // start TCP port for listeners
 let lastUsedPort = 19000 + parseInt(process.env.JEST_WORKER_ID || '1') * 1000


### PR DESCRIPTION
Add two new metrics

`dcl_error_cannot_estimate_gas_transactions_biconomy`: Track transactions that failed by unpredictable gas limit
`dcl_error_relay_transactions_biconomy`: Track Biconomy API errors

Also, I've moved `dcl_sent_transactions_biconomy` to the end so we can have a total of successful transactions easily