### PR TITLE
feat: Use node 18 alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,12 @@
 ARG RUN
 
-FROM node:lts as builderenv
+FROM node:18-alpine as builderenv
 
 WORKDIR /app
 
 # some packages require a build step
-RUN apt-get update
-RUN apt-get -y -qq install python-setuptools python-dev build-essential
-
-# We use Tini to handle signals and PID1 (https://github.com/krallin/tini, read why here https://github.com/krallin/tini/issues/8)
-ENV TINI_VERSION v0.19.0
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
-RUN chmod +x /tini
+RUN apk update
+RUN apk add --no-cache py3-setuptools python3-dev build-base
 
 # install dependencies
 COPY package.json /app/package.json
@@ -24,23 +19,24 @@ RUN npm run build
 RUN npm run test
 
 # remove devDependencies, keep only used dependencies
-RUN npm ci --only=production
+RUN npm ci --only=production --ignore-scripts
 
 ########################## END OF BUILD STAGE ##########################
 
-FROM node:lts
+FROM node:18-alpine
+
+RUN apk update
+RUN apk add --no-cache tini
 
 # NODE_ENV is used to configure some runtime options, like JSON logger
 ENV NODE_ENV production
 
 WORKDIR /app
 COPY --from=builderenv /app /app
-COPY --from=builderenv /tini /tini
 # Please _DO NOT_ use a custom ENTRYPOINT because it may prevent signals
 # (i.e. SIGTERM) to reach the service
 # Read more here: https://aws.amazon.com/blogs/containers/graceful-shutdowns-with-ecs/
 #            and: https://www.ctl.io/developers/blog/post/gracefully-stopping-docker-containers/
-ENTRYPOINT ["/tini", "--"]
+ENTRYPOINT ["/sbin/tini", "--"]
 # Run the program under Tini
-
-CMD [ "/usr/local/bin/node", "--abort-on-uncaught-exception", "--unhandled-rejections=strict", "dist/index.js" ]
+CMD [ "/usr/local/bin/node", "--trace-warnings", "--abort-on-uncaught-exception", "--unhandled-rejections=strict", "dist/index.js" ]


### PR DESCRIPTION
This PR uses node 18 alpine as the base docker image to reduce its size and vulnerabilities.