### PR TITLE
feat: remove contract label for transaction metric

### DIFF
--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -11,7 +11,7 @@ export const metricDeclarations = {
   dcl_sent_transactions_biconomy: {
     help: 'Count transactions sent to BICONOMY',
     type: IMetricsComponent.CounterType,
-    labelNames: ['contract'],
+    labelNames: [],
   },
   dcl_error_limit_reached_transactions_biconomy: {
     help: 'Count limit errors when trying to relay a transaction to BICONOMY',

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -6,7 +6,7 @@ export const metricDeclarations = {
   dcl_error_sale_price_too_low: {
     help: 'The transaction sale price trying to be executed is too low',
     type: IMetricsComponent.CounterType,
-    labelNames: ['contract', 'minPrice', 'salePrice'],
+    labelNames: ['minPrice', 'salePrice'],
   },
   dcl_sent_transactions_biconomy: {
     help: 'Count transactions sent to BICONOMY',
@@ -16,17 +16,17 @@ export const metricDeclarations = {
   dcl_error_limit_reached_transactions_biconomy: {
     help: 'Count limit errors when trying to relay a transaction to BICONOMY',
     type: IMetricsComponent.CounterType,
-    labelNames: ['contract', 'code'],
+    labelNames: ['code'],
   },
   dcl_error_cannot_estimate_gas_transactions_biconomy: {
     help: 'Count errors of cannot estimate gas when trying to relay a transaction to BICONOMY',
     type: IMetricsComponent.CounterType,
-    labelNames: ['contract'],
+    labelNames: [],
   },
   dcl_error_relay_transactions_biconomy: {
     help: 'Count errors of BICONOMY Api when trying to relay a transaction to BICONOMY',
     type: IMetricsComponent.CounterType,
-    labelNames: ['contract'],
+    labelNames: [],
   },
   ...thegraphMetrics,
 }

--- a/src/ports/transaction/component.ts
+++ b/src/ports/transaction/component.ts
@@ -48,10 +48,6 @@ export function createTransactionComponent(
       method: 'POST',
     })
 
-    const metricPayload = {
-      contract: transactionData.params[0],
-    }
-
     if (result.status !== MetaTransactionStatus.OK) {
       let message: string | undefined
       let code: ErrorCode | undefined
@@ -65,7 +61,6 @@ export function createTransactionComponent(
 
           // A limit was reached, check ErrorCode for possible values
           metrics.increment('dcl_error_limit_reached_transactions_biconomy', {
-            ...metricPayload,
             code,
           })
           break
@@ -74,18 +69,14 @@ export function createTransactionComponent(
 
           // This error happens when the contract execution will fail. See https://github.com/decentraland/transactions-server/blob/2e5d833f672a87a7acf0ff761f986421676c4ec9/ERRORS.md
           metrics.increment(
-            'dcl_error_cannot_estimate_gas_transactions_biconomy',
-            metricPayload
+            'dcl_error_cannot_estimate_gas_transactions_biconomy'
           )
           break
         case MetaTransactionStatus.NOT_FOUND:
         case MetaTransactionStatus.INTERNAL_SERVER_ERROR:
         default:
           // Any other error is related to the Biconomy API
-          metrics.increment(
-            'dcl_error_relay_transactions_biconomy',
-            metricPayload
-          )
+          metrics.increment('dcl_error_relay_transactions_biconomy')
           break
       }
 
@@ -100,7 +91,7 @@ export function createTransactionComponent(
 
     const data: MetaTransactionResponse = await result.json()
 
-    metrics.increment('dcl_sent_transactions_biconomy', metricPayload)
+    metrics.increment('dcl_sent_transactions_biconomy')
 
     return data.txHash!
   }

--- a/src/ports/transaction/validation/checkSalePrice.ts
+++ b/src/ports/transaction/validation/checkSalePrice.ts
@@ -25,7 +25,6 @@ export const checkSalePrice: ITransactionValidator = async (
 
   if (salePrice !== null && BigNumber.from(salePrice).lt(minPriceInWei)) {
     metrics.increment('dcl_error_sale_price_too_low', {
-      contract: params[0],
       minPrice: minPriceInWei,
       salePrice,
     })

--- a/test/tests/ports/transaction/biconomy.spec.ts
+++ b/test/tests/ports/transaction/biconomy.spec.ts
@@ -45,9 +45,7 @@ test('biconomy flow test', function ({ components, stubComponents }) {
     expect({ result }).toEqual({ result: response.txHash })
 
     expect(
-      metrics.increment.calledOnceWith('dcl_sent_transactions_biconomy', {
-        contract: tx.params[0],
-      })
+      metrics.increment.calledOnceWith('dcl_sent_transactions_biconomy')
     ).toEqual(true)
   })
 
@@ -68,12 +66,7 @@ test('biconomy flow test', function ({ components, stubComponents }) {
     )
 
     expect(
-      metrics.increment.calledOnceWith(
-        'dcl_error_relay_transactions_biconomy',
-        {
-          contract: tx.params[0],
-        }
-      )
+      metrics.increment.calledOnceWith('dcl_error_relay_transactions_biconomy')
     ).toEqual(true)
   })
 
@@ -99,10 +92,7 @@ test('biconomy flow test', function ({ components, stubComponents }) {
 
     expect(
       metrics.increment.calledOnceWith(
-        'dcl_error_cannot_estimate_gas_transactions_biconomy',
-        {
-          contract: tx.params[0],
-        }
+        'dcl_error_cannot_estimate_gas_transactions_biconomy'
       )
     ).toEqual(true)
   })
@@ -135,7 +125,6 @@ test('biconomy flow test', function ({ components, stubComponents }) {
       metrics.increment.calledOnceWith(
         'dcl_error_limit_reached_transactions_biconomy',
         {
-          contract: tx.params[0],
           code: ErrorCode.DAPP_LIMIT_REACHED,
         }
       )


### PR DESCRIPTION
We are distinguishing the amount of transactions for each contract in prometheus but we are not using that metric categorization. This PR removes the contract for the event in an approach to reduce the amount of unique labels saved in prmetheus