### PR TITLE
feat: Improve the transaction middleware errors

### DIFF
--- a/src/logic/transaction-middleware.ts
+++ b/src/logic/transaction-middleware.ts
@@ -26,13 +26,7 @@ export function createTransactionMiddleware(
       logger.debug(
         'Checking the validity of the request before sending the transaction'
       )
-      const id = Date.now()
-
-      logger.info(`Cloning the request when validating the tx ${id}`)
       const { transactionData } = await context.request.clone().json()
-      logger.info(
-        `Finish cloning the request when validating the tx ${id} and data: ${transactionData}`
-      )
 
       if (!transactionData) {
         logger.warn('Transaction rejected due to missing transaction data')
@@ -52,7 +46,6 @@ export function createTransactionMiddleware(
 
       return await next()
     } catch (error) {
-
       if (error instanceof HighCongestionError) {
         logger.warn('Transaction rejected due to high network congestion', {
           from,

--- a/src/logic/transaction-middleware.ts
+++ b/src/logic/transaction-middleware.ts
@@ -1,7 +1,12 @@
 import { IHttpServerComponent } from '@well-known-components/interfaces'
 import {
   HighCongestionError,
+  InvalidContractAddressError,
+  InvalidSalePriceError,
+  InvalidSchemaError,
   InvalidTransactionError,
+  QuotaReachedError,
+  SimulateTransactionError,
 } from '../types/transactions/errors'
 import { AppComponents, Context } from '../types'
 import { HTTPResponse, StatusCode } from '../types/HTTPResponse'
@@ -15,6 +20,8 @@ export function createTransactionMiddleware(
     context,
     next
   ): Promise<IHttpServerComponent.IResponse | HTTPResponse> => {
+    let from = 'unknown'
+
     try {
       logger.debug(
         'Checking the validity of the request before sending the transaction'
@@ -28,21 +35,31 @@ export function createTransactionMiddleware(
       )
 
       if (!transactionData) {
-        throw new Error(
-          'Missing transaction data. Please add it to the body of the request as `transactionData`'
-        )
+        logger.warn('Transaction rejected due to missing transaction data')
+        return {
+          status: StatusCode.BAD_REQUEST,
+          body: {
+            ok: false,
+            message:
+              'Missing transaction data. Please add it to the body of the request as `transactionData`',
+          },
+        }
       }
+
+      from = transactionData.from
 
       await transaction.checkData(transactionData)
 
       return await next()
     } catch (error) {
-      logger.error(error as Error, {
-        method: context.request.method,
-        url: context.request.url,
-      })
 
       if (error instanceof HighCongestionError) {
+        logger.warn('Transaction rejected due to high network congestion', {
+          from,
+
+          currentGasPrice: error.currentGasPrice,
+          maxGasPriceAllowed: error.maxGasPriceAllowed,
+        })
         return {
           status: StatusCode.SERVICE_UNAVAILABLE,
           body: {
@@ -53,8 +70,97 @@ export function createTransactionMiddleware(
         }
       }
 
+      if (error instanceof QuotaReachedError) {
+        logger.warn('Transaction rejected due to quota reached', {
+          from,
+
+          currentQuota: error.currentQuota.toString(),
+        })
+        return {
+          status: StatusCode.TOO_MANY_REQUESTS,
+          body: {
+            ok: false,
+            message: error.message,
+            code: error.code,
+          },
+        }
+      }
+
+      if (error instanceof InvalidSchemaError) {
+        logger.warn('Transaction rejected due to invalid schema', {
+          from,
+
+          schemaErrors: JSON.stringify(error.schemaErrors),
+        })
+        return {
+          status: StatusCode.BAD_REQUEST,
+          body: {
+            ok: false,
+            message: error.message,
+            code: error.code,
+          },
+        }
+      }
+
+      if (error instanceof InvalidSalePriceError) {
+        logger.warn('Transaction rejected due to sale price too low', {
+          from,
+
+          minPrice: error.minPrice,
+          salePrice: error.salePrice,
+        })
+        return {
+          status: StatusCode.BAD_REQUEST,
+          body: {
+            ok: false,
+            message: error.message,
+            code: error.code,
+          },
+        }
+      }
+
+      if (error instanceof InvalidContractAddressError) {
+        logger.warn('Transaction rejected due to invalid contract address', {
+          from,
+
+          contractAddress: error.contractAddress,
+        })
+        return {
+          status: StatusCode.BAD_REQUEST,
+          body: {
+            ok: false,
+            message: error.message,
+            code: error.code,
+          },
+        }
+      }
+
+      if (
+        error instanceof InvalidTransactionError ||
+        error instanceof SimulateTransactionError
+      ) {
+        logger.warn('Transaction rejected due to invalid transaction data', {
+          from,
+
+          message: error.message,
+        })
+        return {
+          status: StatusCode.BAD_REQUEST,
+          body: {
+            ok: false,
+            message: error.message,
+            code: error.code,
+          },
+        }
+      }
+
+      logger.error('Unexpected error during transaction validation', {
+        from,
+        message: (error as Error).message,
+        stack: (error as Error).stack ?? '',
+      })
       return {
-        status: StatusCode.UNAUTHORIZED,
+        status: StatusCode.ERROR,
         body: {
           ok: false,
           message: (error as Error).message,

--- a/src/types/HTTPResponse.ts
+++ b/src/types/HTTPResponse.ts
@@ -6,6 +6,7 @@ export enum StatusCode {
   BAD_REQUEST = 400,
   UNAUTHORIZED = 401,
   NOT_FOUND = 404,
+  TOO_MANY_REQUESTS = 429,
   LOCKED = 423,
   CONFLICT = 409,
   ERROR = 500,

--- a/test/tests/logic/transaction-middleware.spec.ts
+++ b/test/tests/logic/transaction-middleware.spec.ts
@@ -1,0 +1,407 @@
+import { IHttpServerComponent } from '@well-known-components/interfaces'
+import { ErrorCode } from 'decentraland-transactions'
+import { createTransactionMiddleware } from '../../../src/logic/transaction-middleware'
+import {
+  HighCongestionError,
+  InvalidContractAddressError,
+  InvalidSalePriceError,
+  InvalidSchemaError,
+  InvalidTransactionError,
+  QuotaReachedError,
+  SimulateTransactionError,
+} from '../../../src/types/transactions/errors'
+import { StatusCode } from '../../../src/types/HTTPResponse'
+import { AppComponents } from '../../../src/types'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let middleware: IHttpServerComponent.IRequestHandler<any>
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let context: any
+let next: jest.Mock
+let loggerDebug: jest.Mock
+let loggerInfo: jest.Mock
+let loggerWarn: jest.Mock
+let loggerError: jest.Mock
+let checkDataMock: jest.Mock
+let transactionData: { from: string; params: string[] }
+
+beforeEach(() => {
+  loggerDebug = jest.fn()
+  loggerInfo = jest.fn()
+  loggerWarn = jest.fn()
+  loggerError = jest.fn()
+  checkDataMock = jest.fn()
+  next = jest.fn()
+
+  transactionData = {
+    from: '0x9Ab8A53AA9695dAb57e62684aBA6978E5225ED0b',
+    params: ['0x1234', '0x5678'],
+  }
+
+  const components = {
+    logs: {
+      getLogger: jest.fn().mockReturnValue({
+        debug: loggerDebug,
+        info: loggerInfo,
+        warn: loggerWarn,
+        error: loggerError,
+        log: jest.fn(),
+      }),
+    },
+    transaction: {
+      checkData: checkDataMock,
+      sendMetaTransaction: jest.fn(),
+      insert: jest.fn(),
+      getByUserAddress: jest.fn(),
+    },
+  } as unknown as Pick<AppComponents, 'logs' | 'transaction'>
+
+  middleware = createTransactionMiddleware(components)
+
+  context = {
+    request: {
+      method: 'POST',
+      url: 'http://localhost/v1/transactions',
+      clone: () => ({
+        json: () => Promise.resolve({ transactionData }),
+      }),
+    },
+  }
+})
+
+afterEach(() => {
+  jest.restoreAllMocks()
+})
+
+describe('when the request is valid and checkData passes', () => {
+  let nextResponse: IHttpServerComponent.IResponse
+
+  beforeEach(() => {
+    checkDataMock.mockResolvedValueOnce(undefined)
+    nextResponse = { status: 200, body: { ok: true, txHash: '0xabc' } }
+    next.mockResolvedValueOnce(nextResponse)
+  })
+
+  it('should call next and return its response', async () => {
+    const result = await middleware(context, next)
+
+    expect(result).toEqual(nextResponse)
+    expect(next).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('when transactionData is missing from the request body', () => {
+  beforeEach(() => {
+    context = {
+      request: {
+        method: 'POST',
+        url: 'http://localhost/v1/transactions',
+        clone: () => ({
+          json: () => Promise.resolve({}),
+        }),
+      },
+    }
+  })
+
+  it('should respond with a 400 and the missing data message', async () => {
+    const result = await middleware(context, next)
+
+    expect(result).toEqual({
+      status: StatusCode.BAD_REQUEST,
+      body: {
+        ok: false,
+        message:
+          'Missing transaction data. Please add it to the body of the request as `transactionData`',
+      },
+    })
+  })
+
+  it('should log a warning', async () => {
+    await middleware(context, next)
+
+    expect(loggerWarn).toHaveBeenCalledWith(
+      'Transaction rejected due to missing transaction data'
+    )
+  })
+})
+
+describe('when checkData throws a HighCongestionError', () => {
+  let error: HighCongestionError
+
+  beforeEach(() => {
+    error = new HighCongestionError('2100000000', '2000000000')
+    checkDataMock.mockRejectedValueOnce(error)
+  })
+
+  it('should respond with a 503 and the error', async () => {
+    const result = await middleware(context, next)
+
+    expect(result).toEqual({
+      status: StatusCode.SERVICE_UNAVAILABLE,
+      body: {
+        ok: false,
+        message: error.message,
+        code: ErrorCode.HIGH_CONGESTION,
+      },
+    })
+  })
+
+  it('should log a warning with the address and gas price details', async () => {
+    await middleware(context, next)
+
+    expect(loggerWarn).toHaveBeenCalledWith(
+      'Transaction rejected due to high network congestion',
+      {
+        from: '0x9Ab8A53AA9695dAb57e62684aBA6978E5225ED0b',
+        currentGasPrice: '2100000000',
+        maxGasPriceAllowed: '2000000000',
+      }
+    )
+  })
+})
+
+describe('when checkData throws a QuotaReachedError', () => {
+  let error: QuotaReachedError
+
+  beforeEach(() => {
+    error = new QuotaReachedError(
+      '0x9Ab8A53AA9695dAb57e62684aBA6978E5225ED0b',
+      10
+    )
+    checkDataMock.mockRejectedValueOnce(error)
+  })
+
+  it('should respond with a 429 and the error', async () => {
+    const result = await middleware(context, next)
+
+    expect(result).toEqual({
+      status: StatusCode.TOO_MANY_REQUESTS,
+      body: {
+        ok: false,
+        message: error.message,
+        code: ErrorCode.QUOTA_REACHED,
+      },
+    })
+  })
+
+  it('should log a warning with the address and quota', async () => {
+    await middleware(context, next)
+
+    expect(loggerWarn).toHaveBeenCalledWith(
+      'Transaction rejected due to quota reached',
+      {
+        from: '0x9Ab8A53AA9695dAb57e62684aBA6978E5225ED0b',
+        currentQuota: '10',
+      }
+    )
+  })
+})
+
+describe('when checkData throws an InvalidSchemaError', () => {
+  let error: InvalidSchemaError
+
+  beforeEach(() => {
+    const schemaErrors = [
+      { message: 'must have required property "from"' },
+    ] as InvalidSchemaError['schemaErrors']
+    error = new InvalidSchemaError(schemaErrors)
+    checkDataMock.mockRejectedValueOnce(error)
+  })
+
+  it('should respond with a 400 and the error', async () => {
+    const result = await middleware(context, next)
+
+    expect(result).toEqual({
+      status: StatusCode.BAD_REQUEST,
+      body: {
+        ok: false,
+        message: error.message,
+        code: ErrorCode.INVALID_SCHEMA,
+      },
+    })
+  })
+
+  it('should log a warning with the address and schema error details', async () => {
+    await middleware(context, next)
+
+    expect(loggerWarn).toHaveBeenCalledWith(
+      'Transaction rejected due to invalid schema',
+      {
+        from: '0x9Ab8A53AA9695dAb57e62684aBA6978E5225ED0b',
+        schemaErrors: JSON.stringify(error.schemaErrors),
+      }
+    )
+  })
+})
+
+describe('when checkData throws an InvalidSalePriceError', () => {
+  let error: InvalidSalePriceError
+
+  beforeEach(() => {
+    error = new InvalidSalePriceError('1000000000000000000', '500000000000000000')
+    checkDataMock.mockRejectedValueOnce(error)
+  })
+
+  it('should respond with a 400 and the error', async () => {
+    const result = await middleware(context, next)
+
+    expect(result).toEqual({
+      status: StatusCode.BAD_REQUEST,
+      body: {
+        ok: false,
+        message: error.message,
+        code: ErrorCode.SALE_PRICE_TOO_LOW,
+      },
+    })
+  })
+
+  it('should log a warning with the address and price details', async () => {
+    await middleware(context, next)
+
+    expect(loggerWarn).toHaveBeenCalledWith(
+      'Transaction rejected due to sale price too low',
+      {
+        from: '0x9Ab8A53AA9695dAb57e62684aBA6978E5225ED0b',
+        minPrice: '1000000000000000000',
+        salePrice: '500000000000000000',
+      }
+    )
+  })
+})
+
+describe('when checkData throws an InvalidContractAddressError', () => {
+  let error: InvalidContractAddressError
+
+  beforeEach(() => {
+    error = new InvalidContractAddressError('0xdeadbeef')
+    checkDataMock.mockRejectedValueOnce(error)
+  })
+
+  it('should respond with a 400 and the error', async () => {
+    const result = await middleware(context, next)
+
+    expect(result).toEqual({
+      status: StatusCode.BAD_REQUEST,
+      body: {
+        ok: false,
+        message: error.message,
+        code: ErrorCode.INVALID_CONTRACT_ADDRESS,
+      },
+    })
+  })
+
+  it('should log a warning with the address and contract address', async () => {
+    await middleware(context, next)
+
+    expect(loggerWarn).toHaveBeenCalledWith(
+      'Transaction rejected due to invalid contract address',
+      {
+        from: '0x9Ab8A53AA9695dAb57e62684aBA6978E5225ED0b',
+        contractAddress: '0xdeadbeef',
+      }
+    )
+  })
+})
+
+describe('when checkData throws an InvalidTransactionError', () => {
+  let error: InvalidTransactionError
+
+  beforeEach(() => {
+    error = new InvalidTransactionError('Transaction is invalid')
+    checkDataMock.mockRejectedValueOnce(error)
+  })
+
+  it('should respond with a 400 and the error', async () => {
+    const result = await middleware(context, next)
+
+    expect(result).toEqual({
+      status: StatusCode.BAD_REQUEST,
+      body: {
+        ok: false,
+        message: error.message,
+        code: ErrorCode.INVALID_TRANSACTION,
+      },
+    })
+  })
+
+  it('should log a warning with the address and error message', async () => {
+    await middleware(context, next)
+
+    expect(loggerWarn).toHaveBeenCalledWith(
+      'Transaction rejected due to invalid transaction data',
+      {
+        from: '0x9Ab8A53AA9695dAb57e62684aBA6978E5225ED0b',
+        message: 'Transaction is invalid',
+      }
+    )
+  })
+})
+
+describe('when checkData throws a SimulateTransactionError', () => {
+  let error: SimulateTransactionError
+
+  beforeEach(() => {
+    error = new SimulateTransactionError('Simulation failed')
+    checkDataMock.mockRejectedValueOnce(error)
+  })
+
+  it('should respond with a 400 and the error', async () => {
+    const result = await middleware(context, next)
+
+    expect(result).toEqual({
+      status: StatusCode.BAD_REQUEST,
+      body: {
+        ok: false,
+        message: error.message,
+        code: ErrorCode.INVALID_TRANSACTION,
+      },
+    })
+  })
+
+  it('should log a warning with the address and error message', async () => {
+    await middleware(context, next)
+
+    expect(loggerWarn).toHaveBeenCalledWith(
+      'Transaction rejected due to invalid transaction data',
+      {
+        from: '0x9Ab8A53AA9695dAb57e62684aBA6978E5225ED0b',
+        message: error.message,
+      }
+    )
+  })
+})
+
+describe('when checkData throws an unexpected error', () => {
+  let error: Error
+
+  beforeEach(() => {
+    error = new Error('Something went wrong')
+    checkDataMock.mockRejectedValueOnce(error)
+  })
+
+  it('should respond with a 500 and the error', async () => {
+    const result = await middleware(context, next)
+
+    expect(result).toEqual({
+      status: StatusCode.ERROR,
+      body: {
+        ok: false,
+        message: 'Something went wrong',
+        code: undefined,
+      },
+    })
+  })
+
+  it('should log the error with the address, message, and stack trace', async () => {
+    await middleware(context, next)
+
+    expect(loggerError).toHaveBeenCalledWith(
+      'Unexpected error during transaction validation',
+      {
+        from: '0x9Ab8A53AA9695dAb57e62684aBA6978E5225ED0b',
+        message: 'Something went wrong',
+        stack: expect.stringContaining('Something went wrong'),
+      }
+    )
+  })
+})


### PR DESCRIPTION
The transaction middleware was returning `401 Unauthorized` for all validation errors, which is incorrect — none of these failures are authentication issues. This made it harder for clients to understand what went wrong and for us to debug issues in production, since every error looked the same in both the response and the logs.

Additionally, every error was logged twice (a generic `logger.error` plus a specific log per branch), and noisy `logger.info` calls on every request added clutter without diagnostic value.

### How

**Replaced the catch-all 401 with error-specific HTTP status codes:**

| Error | Status |
|---|---|
| Missing `transactionData` | 400 Bad Request |
| `InvalidSchemaError` | 400 Bad Request |
| `InvalidTransactionError` / `SimulateTransactionError` | 400 Bad Request |
| `InvalidSalePriceError` | 400 Bad Request |
| `InvalidContractAddressError` | 400 Bad Request |
| `QuotaReachedError` | 429 Too Many Requests |
| `HighCongestionError` | 503 Service Unavailable (unchanged) |
| Unexpected errors | 500 Internal Server Error |

**Improved logging so each error is logged exactly once with relevant context:**

- Each known error logs at `warn` level with the `from` address and error-specific fields (e.g. gas prices, quota, contract address).
- Unexpected errors log at `error` level with the `from` address, message, and stack trace.
- Removed the generic `logger.error` at the top of the catch block that duplicated every log.
- Removed the `logger.info` calls for request cloning that fired on every request without adding value.