### PR TITLE
refactor: introduce relayer abstraction on AppComponents

### DIFF
--- a/src/components.ts
+++ b/src/components.ts
@@ -104,13 +104,13 @@ export async function initComponents(): Promise<AppComponents> {
   })
 
   // Initialize each provider whose required config is present so both can
-  // coexist. When both are available, the relay-provider feature flag picks
-  // which one handles each transaction.
-  let gelatoComponent: AppComponents['gelato'] | undefined
+  // coexist. The relay router arbitrates between them via the relay-provider
+  // feature flag (and throws if neither is configured).
+  let gelato: AppComponents['gelato']
   let openzeppelin: AppComponents['openzeppelin']
 
   if (await config.getString('GELATO_API_KEY')) {
-    gelatoComponent = await createGelatoComponent({ logs, config, metrics })
+    gelato = await createGelatoComponent({ logs, config, metrics })
   }
 
   if (await config.getString('OZ_RELAYER_URL')) {
@@ -122,23 +122,12 @@ export async function initComponents(): Promise<AppComponents> {
     })
   }
 
-  let gelato: AppComponents['gelato']
-  if (gelatoComponent && openzeppelin) {
-    gelato = createRelayRouterComponent({
-      logs,
-      features,
-      gelato: gelatoComponent,
-      openzeppelin,
-    })
-  } else if (gelatoComponent) {
-    gelato = gelatoComponent
-  } else if (openzeppelin) {
-    gelato = openzeppelin
-  } else {
-    throw new Error(
-      'No relay provider configured. Set GELATO_API_KEY or OZ_RELAYER_URL.'
-    )
-  }
+  const relayer = createRelayRouterComponent({
+    logs,
+    features,
+    gelato,
+    openzeppelin,
+  })
 
   const transaction = createTransactionComponent({
     config,
@@ -146,7 +135,7 @@ export async function initComponents(): Promise<AppComponents> {
     fetcher,
     logs,
     pg,
-    gelato,
+    relayer,
     contracts,
     metrics,
   })
@@ -161,6 +150,7 @@ export async function initComponents(): Promise<AppComponents> {
     metrics,
     server,
     pg,
+    relayer,
     gelato,
     openzeppelin,
     transaction,

--- a/src/ports/relay-router/components.ts
+++ b/src/ports/relay-router/components.ts
@@ -28,7 +28,9 @@ export function createRelayRouterComponent(
 
   const availableNames = Object.keys(available)
   if (availableNames.length === 0) {
-    throw new Error('relay-router: no providers available')
+    throw new Error(
+      'relay-router: no providers configured; set GELATO_API_KEY or OZ_RELAYER_URL to enable at least one relayer'
+    )
   }
 
   async function resolveProvider(): Promise<{

--- a/src/ports/transaction/component.ts
+++ b/src/ports/transaction/component.ts
@@ -22,15 +22,15 @@ export function createTransactionComponent(
     | 'fetcher'
     | 'logs'
     | 'metrics'
-    | 'gelato'
+    | 'relayer'
   >
 ): ITransactionComponent {
-  const { gelato, pg } = components
+  const { relayer, pg } = components
 
   async function sendMetaTransaction(
     transactionData: TransactionData
   ): Promise<string> {
-    return gelato.sendMetaTransaction(transactionData)
+    return relayer.sendMetaTransaction(transactionData)
   }
 
   async function insert(

--- a/src/ports/transaction/validation/checkGasPrice.ts
+++ b/src/ports/transaction/validation/checkGasPrice.ts
@@ -83,11 +83,11 @@ const getMaxGasPriceAllowed = async (
  * @param chainId - Network Chain ID
  */
 const getNetworkGasPrice = async (
-  components: Pick<AppComponents, 'gelato'>,
+  components: Pick<AppComponents, 'relayer'>,
   chainId: ChainId
 ): Promise<bigint | null> => {
-  const { gelato } = components
-  return gelato.getNetworkGasPrice(chainId)
+  const { relayer } = components
+  return relayer.getNetworkGasPrice(chainId)
 }
 
 /**

--- a/src/ports/transaction/validation/types.ts
+++ b/src/ports/transaction/validation/types.ts
@@ -13,7 +13,7 @@ export type ITransactionValidator = (
 export type IGasPriceValidator = (
   components: Pick<
     AppComponents,
-    'config' | 'contracts' | 'features' | 'gelato' | 'metrics'
+    'config' | 'contracts' | 'features' | 'relayer' | 'metrics'
   >,
   transactionData: TransactionData
 ) => Promise<void>

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,7 @@ import { IContractsComponent } from './ports/contracts/types'
 import { ITransactionComponent } from './ports/transaction/types'
 import { GelatoMetaTransactionComponent } from './ports/gelato'
 import { OpenZeppelinMetaTransactionComponent } from './ports/openzeppelin'
+import { IMetaTransactionProviderComponent } from './types/transactions/transactions'
 
 export type GlobalContext = {
   components: AppComponents
@@ -24,7 +25,8 @@ export type BaseComponents = {
   config: IConfigComponent
   logs: ILoggerComponent
   globalLogger: ILoggerComponent.ILogger
-  gelato: GelatoMetaTransactionComponent
+  relayer: IMetaTransactionProviderComponent
+  gelato?: GelatoMetaTransactionComponent
   openzeppelin?: OpenZeppelinMetaTransactionComponent
   features: IFeaturesComponent
   fetcher: IFetchComponent

--- a/test/tests/ports/openzeppelin/openzeppelin-component.spec.ts
+++ b/test/tests/ports/openzeppelin/openzeppelin-component.spec.ts
@@ -1,0 +1,598 @@
+import {
+  IConfigComponent,
+  ILoggerComponent,
+  IMetricsComponent,
+} from '@well-known-components/interfaces'
+import { IFetchComponent } from '@well-known-components/http-server'
+import { ChainId } from '@dcl/schemas'
+import { ErrorCode } from 'decentraland-transactions'
+import { metricDeclarations } from '../../../../src/metrics'
+import { createOpenZeppelinComponent } from '../../../../src/ports/openzeppelin'
+import { OpenZeppelinMetaTransactionComponent } from '../../../../src/ports/openzeppelin/types'
+import {
+  InvalidTransactionError,
+  RelayerError,
+  RelayerTimeout,
+  TransactionData,
+} from '../../../../src/types/transactions'
+import { createCollection } from '../../../mocks/transactionData'
+
+const mockGetGasPrice = jest.fn()
+
+jest.mock('viem', () => {
+  const actual = jest.requireActual('viem')
+  return {
+    ...actual,
+    createPublicClient: () => ({
+      getGasPrice: mockGetGasPrice,
+    }),
+  }
+})
+
+const RELAYER_URL = 'https://oz.example.com'
+const RELAYER_ID = 'relayer-1'
+const TX_ENDPOINT = `${RELAYER_URL}/api/v1/relayers/${RELAYER_ID}/transactions`
+const STATUS_ENDPOINT = `${RELAYER_URL}/api/v1/relayers/${RELAYER_ID}/status`
+
+type MockResponse = {
+  ok: boolean
+  status: number
+  json: jest.Mock
+  text: jest.Mock
+}
+
+function createResponse(overrides: Partial<MockResponse> = {}): MockResponse {
+  return {
+    ok: true,
+    status: 200,
+    json: jest.fn(),
+    text: jest.fn(),
+    ...overrides,
+  }
+}
+
+let openzeppelin: OpenZeppelinMetaTransactionComponent
+let logs: ILoggerComponent
+let metrics: IMetricsComponent<keyof typeof metricDeclarations>
+let config: IConfigComponent
+let fetcher: IFetchComponent
+let fetchMock: jest.Mock
+let getStringMock: jest.Mock
+let transactionData: TransactionData
+
+beforeEach(async () => {
+  mockGetGasPrice.mockReset()
+  fetchMock = jest.fn()
+  getStringMock = jest.fn(async (key: string) => {
+    switch (key) {
+      case 'OZ_RELAYER_SPEED':
+        return 'fast'
+      case 'RPC_URL':
+        return 'https://rpc.example.com'
+      default:
+        return undefined
+    }
+  })
+  logs = {
+    getLogger: () => ({
+      error: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      log: jest.fn(),
+      debug: jest.fn(),
+    }),
+  } as ILoggerComponent
+  metrics = {
+    increment: jest.fn(),
+    startTimer: jest.fn(),
+    stopTimer: jest.fn(),
+    reset: jest.fn(),
+    resetAll: jest.fn(),
+    observe: jest.fn(),
+    decrement: jest.fn(),
+    getValue: jest.fn(),
+  } as IMetricsComponent<keyof typeof metricDeclarations>
+  config = {
+    requireString: async (key: string) => {
+      switch (key) {
+        case 'OZ_RELAYER_URL':
+          return RELAYER_URL
+        case 'OZ_RELAYER_API_KEY':
+          return 'api-key'
+        case 'OZ_RELAYER_ID':
+          return RELAYER_ID
+        default:
+          throw new Error(`Unknown key: ${key}`)
+      }
+    },
+    requireNumber: jest.fn(),
+    getString: getStringMock,
+    getNumber: jest.fn(),
+  } as IConfigComponent
+  fetcher = { fetch: fetchMock } as IFetchComponent
+  transactionData = createCollection
+  openzeppelin = await createOpenZeppelinComponent({
+    config,
+    logs,
+    metrics,
+    fetcher,
+  })
+})
+
+afterEach(() => {
+  jest.restoreAllMocks()
+})
+
+describe('when sending a meta transaction', () => {
+  describe('and the relayer responds immediately with a hash and success=true', () => {
+    let response: MockResponse
+
+    beforeEach(() => {
+      response = createResponse({
+        json: jest.fn().mockResolvedValueOnce({
+          success: true,
+          data: {
+            id: 'oz-tx-id',
+            hash: '0xaTransactionHash',
+            status: 'submitted',
+            status_reason: null,
+          },
+          error: null,
+        }),
+      })
+      fetchMock.mockResolvedValueOnce(response)
+    })
+
+    it('should resolve to the transaction hash', () => {
+      return expect(
+        openzeppelin.sendMetaTransaction(transactionData)
+      ).resolves.toBe('0xaTransactionHash')
+    })
+
+    it('should increment the sent transactions metric', async () => {
+      await openzeppelin.sendMetaTransaction(transactionData)
+      expect(metrics.increment).toHaveBeenCalledWith(
+        'dcl_sent_transactions_openzeppelin'
+      )
+    })
+
+    it('should call the relayer with to, data, speed, and a zero value', async () => {
+      await openzeppelin.sendMetaTransaction(transactionData)
+      expect(fetchMock).toHaveBeenCalledWith(
+        TX_ENDPOINT,
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            to: transactionData.params[0],
+            data: transactionData.params[1],
+            speed: 'fast',
+            value: '0x0',
+          }),
+        })
+      )
+    })
+
+    it('should include the bearer token and the content type headers', async () => {
+      await openzeppelin.sendMetaTransaction(transactionData)
+      expect(fetchMock).toHaveBeenCalledWith(
+        TX_ENDPOINT,
+        expect.objectContaining({
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: 'Bearer api-key',
+          },
+        })
+      )
+    })
+  })
+
+  describe('and the fetcher throws an error', () => {
+    beforeEach(() => {
+      fetchMock.mockRejectedValueOnce(new Error('network down'))
+    })
+
+    it('should reject with a RelayerError carrying status 500 and the underlying message', () => {
+      return expect(
+        openzeppelin.sendMetaTransaction(transactionData)
+      ).rejects.toThrow(new RelayerError(500, 'network down'))
+    })
+
+    it('should increment the service errors metric', async () => {
+      await expect(
+        openzeppelin.sendMetaTransaction(transactionData)
+      ).rejects.toThrow()
+      expect(metrics.increment).toHaveBeenCalledWith(
+        'dcl_error_service_errors_openzeppelin'
+      )
+    })
+  })
+
+  describe('and the relayer responds with a 422 status', () => {
+    beforeEach(() => {
+      fetchMock.mockResolvedValueOnce(
+        createResponse({
+          ok: false,
+          status: 422,
+          text: jest.fn().mockResolvedValueOnce('validation failed'),
+        })
+      )
+    })
+
+    it('should reject with an InvalidTransactionError carrying the response body', () => {
+      return expect(
+        openzeppelin.sendMetaTransaction(transactionData)
+      ).rejects.toThrow(
+        new InvalidTransactionError(
+          'validation failed',
+          ErrorCode.EXPECTATION_FAILED
+        )
+      )
+    })
+
+    it('should increment the service errors metric', async () => {
+      await expect(
+        openzeppelin.sendMetaTransaction(transactionData)
+      ).rejects.toThrow()
+      expect(metrics.increment).toHaveBeenCalledWith(
+        'dcl_error_service_errors_openzeppelin'
+      )
+    })
+  })
+
+  describe('and the relayer responds with a 400 status', () => {
+    beforeEach(() => {
+      fetchMock.mockResolvedValueOnce(
+        createResponse({
+          ok: false,
+          status: 400,
+          text: jest.fn().mockResolvedValueOnce('bad request'),
+        })
+      )
+    })
+
+    it('should reject with an InvalidTransactionError', () => {
+      return expect(
+        openzeppelin.sendMetaTransaction(transactionData)
+      ).rejects.toThrow(
+        new InvalidTransactionError('bad request', ErrorCode.EXPECTATION_FAILED)
+      )
+    })
+  })
+
+  describe('and the relayer responds with a 500 status', () => {
+    beforeEach(() => {
+      fetchMock.mockResolvedValueOnce(
+        createResponse({
+          ok: false,
+          status: 500,
+          text: jest.fn().mockResolvedValueOnce('internal error'),
+        })
+      )
+    })
+
+    it('should reject with a RelayerError carrying the response status and body', () => {
+      return expect(
+        openzeppelin.sendMetaTransaction(transactionData)
+      ).rejects.toThrow(new RelayerError(500, 'internal error'))
+    })
+  })
+
+  describe('and the relayer responds with success=false in the body', () => {
+    beforeEach(() => {
+      fetchMock.mockResolvedValueOnce(
+        createResponse({
+          json: jest.fn().mockResolvedValueOnce({
+            success: false,
+            data: null,
+            error: 'relayer refused the transaction',
+          }),
+        })
+      )
+    })
+
+    it('should reject with a RelayerError 500 using the error message from the body', () => {
+      return expect(
+        openzeppelin.sendMetaTransaction(transactionData)
+      ).rejects.toThrow(
+        new RelayerError(500, 'relayer refused the transaction')
+      )
+    })
+
+    it('should increment the service errors metric', async () => {
+      await expect(
+        openzeppelin.sendMetaTransaction(transactionData)
+      ).rejects.toThrow()
+      expect(metrics.increment).toHaveBeenCalledWith(
+        'dcl_error_service_errors_openzeppelin'
+      )
+    })
+  })
+
+  describe('and the relayer responds with success=true but no hash yet', () => {
+    beforeEach(() => {
+      fetchMock.mockResolvedValueOnce(
+        createResponse({
+          json: jest.fn().mockResolvedValueOnce({
+            success: true,
+            data: {
+              id: 'oz-tx-id',
+              hash: null,
+              status: 'pending',
+              status_reason: null,
+            },
+            error: null,
+          }),
+        })
+      )
+      jest.useFakeTimers()
+    })
+
+    afterEach(() => {
+      jest.useRealTimers()
+    })
+
+    describe('and polling the transaction returns a hash', () => {
+      beforeEach(() => {
+        fetchMock.mockResolvedValueOnce(
+          createResponse({
+            json: jest.fn().mockResolvedValueOnce({
+              success: true,
+              data: {
+                id: 'oz-tx-id',
+                hash: '0xpolledHash',
+                status: 'submitted',
+                status_reason: null,
+              },
+              error: null,
+            }),
+          })
+        )
+      })
+
+      it('should resolve to the polled transaction hash', async () => {
+        const promise = openzeppelin.sendMetaTransaction(transactionData)
+        await jest.advanceTimersByTimeAsync(2000)
+        await expect(promise).resolves.toBe('0xpolledHash')
+      })
+    })
+
+    describe('and polling the transaction returns a terminal failed status', () => {
+      beforeEach(() => {
+        fetchMock.mockResolvedValueOnce(
+          createResponse({
+            json: jest.fn().mockResolvedValueOnce({
+              success: true,
+              data: {
+                id: 'oz-tx-id',
+                hash: null,
+                status: 'failed',
+                status_reason: 'execution reverted',
+              },
+              error: null,
+            }),
+          })
+        )
+      })
+
+      it('should reject with an InvalidTransactionError carrying the status reason', async () => {
+        const promise = openzeppelin.sendMetaTransaction(transactionData)
+        promise.catch(() => undefined)
+        await jest.advanceTimersByTimeAsync(2000)
+        await expect(promise).rejects.toThrow(
+          new InvalidTransactionError(
+            'Transaction failed: execution reverted',
+            ErrorCode.EXPECTATION_FAILED
+          )
+        )
+      })
+
+      it('should increment the service errors metric', async () => {
+        const promise = openzeppelin.sendMetaTransaction(transactionData)
+        promise.catch(() => undefined)
+        await jest.advanceTimersByTimeAsync(2000)
+        await expect(promise).rejects.toThrow()
+        expect(metrics.increment).toHaveBeenCalledWith(
+          'dcl_error_service_errors_openzeppelin'
+        )
+      })
+    })
+
+    describe('and polling exhausts the maximum number of attempts', () => {
+      beforeEach(() => {
+        // Every poll attempt returns a non-terminal status with no hash
+        fetchMock.mockResolvedValue(
+          createResponse({
+            json: jest.fn().mockResolvedValue({
+              success: true,
+              data: {
+                id: 'oz-tx-id',
+                hash: null,
+                status: 'pending',
+                status_reason: null,
+              },
+              error: null,
+            }),
+          })
+        )
+      })
+
+      it('should reject with a RelayerTimeout', async () => {
+        const promise = openzeppelin.sendMetaTransaction(transactionData)
+        // Suppress unhandled rejection until we assert on it
+        promise.catch(() => undefined)
+        await jest.advanceTimersByTimeAsync(2000 * 30)
+        await expect(promise).rejects.toThrow(
+          new RelayerTimeout('The limit of status checks was reached')
+        )
+      })
+
+      it('should increment the timeout metric', async () => {
+        const promise = openzeppelin.sendMetaTransaction(transactionData)
+        promise.catch(() => undefined)
+        await jest.advanceTimersByTimeAsync(2000 * 30)
+        await expect(promise).rejects.toThrow()
+        expect(metrics.increment).toHaveBeenCalledWith(
+          'dcl_error_timeout_openzeppelin'
+        )
+      })
+    })
+  })
+})
+
+describe('when getting the network gas price', () => {
+  describe('and the RPC client returns a gas price', () => {
+    beforeEach(() => {
+      mockGetGasPrice.mockResolvedValueOnce(42n)
+    })
+
+    it('should resolve to the gas price as a bigint', () => {
+      return expect(
+        openzeppelin.getNetworkGasPrice(ChainId.MATIC_AMOY)
+      ).resolves.toBe(42n)
+    })
+  })
+
+  describe('and the RPC client throws', () => {
+    beforeEach(() => {
+      mockGetGasPrice.mockRejectedValueOnce(new Error('rpc unreachable'))
+    })
+
+    it('should resolve to null instead of propagating the error', () => {
+      return expect(
+        openzeppelin.getNetworkGasPrice(ChainId.MATIC_AMOY)
+      ).resolves.toBeNull()
+    })
+  })
+})
+
+describe('when RPC_URL is not configured', () => {
+  let openzeppelinWithoutRpc: OpenZeppelinMetaTransactionComponent
+
+  beforeEach(async () => {
+    getStringMock.mockImplementation(async (key: string) => {
+      if (key === 'OZ_RELAYER_SPEED') return 'fast'
+      return undefined
+    })
+    openzeppelinWithoutRpc = await createOpenZeppelinComponent({
+      config,
+      logs,
+      metrics,
+      fetcher,
+    })
+  })
+
+  describe('and getting the network gas price', () => {
+    it('should resolve to null without calling the RPC client', async () => {
+      await expect(
+        openzeppelinWithoutRpc.getNetworkGasPrice(ChainId.MATIC_AMOY)
+      ).resolves.toBeNull()
+      expect(mockGetGasPrice).not.toHaveBeenCalled()
+    })
+  })
+})
+
+describe('when checking the readiness probe', () => {
+  describe('and the relayer status endpoint returns ok with a positive balance', () => {
+    beforeEach(() => {
+      fetchMock.mockResolvedValueOnce(
+        createResponse({
+          json: jest.fn().mockResolvedValueOnce({
+            success: true,
+            data: {
+              balance: '1000000000000000000',
+              pending_transactions_count: 0,
+              nonce: '5',
+              paused: false,
+              system_disabled: false,
+            },
+            error: null,
+          }),
+        })
+      )
+    })
+
+    it('should resolve to true', () => {
+      return expect(openzeppelin.readynessProbe()).resolves.toBe(true)
+    })
+
+    it('should call the status endpoint with the bearer token', async () => {
+      await openzeppelin.readynessProbe()
+      expect(fetchMock).toHaveBeenCalledWith(
+        STATUS_ENDPOINT,
+        expect.objectContaining({
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: 'Bearer api-key',
+          },
+        })
+      )
+    })
+  })
+
+  describe('and the relayer status endpoint returns ok with a zero balance', () => {
+    beforeEach(() => {
+      fetchMock.mockResolvedValueOnce(
+        createResponse({
+          json: jest.fn().mockResolvedValueOnce({
+            success: true,
+            data: {
+              balance: '0',
+              pending_transactions_count: 0,
+              nonce: '5',
+              paused: false,
+              system_disabled: false,
+            },
+            error: null,
+          }),
+        })
+      )
+    })
+
+    it('should resolve to false', () => {
+      return expect(openzeppelin.readynessProbe()).resolves.toBe(false)
+    })
+  })
+
+  describe('and the relayer status endpoint returns a non-ok status', () => {
+    beforeEach(() => {
+      fetchMock.mockResolvedValueOnce(
+        createResponse({
+          ok: false,
+          status: 503,
+        })
+      )
+    })
+
+    it('should resolve to false', () => {
+      return expect(openzeppelin.readynessProbe()).resolves.toBe(false)
+    })
+  })
+
+  describe('and the relayer response has success=false', () => {
+    beforeEach(() => {
+      fetchMock.mockResolvedValueOnce(
+        createResponse({
+          json: jest.fn().mockResolvedValueOnce({
+            success: false,
+            data: null,
+            error: 'degraded',
+          }),
+        })
+      )
+    })
+
+    it('should resolve to false', () => {
+      return expect(openzeppelin.readynessProbe()).resolves.toBe(false)
+    })
+  })
+
+  describe('and the fetch call throws', () => {
+    beforeEach(() => {
+      fetchMock.mockRejectedValueOnce(new Error('connection refused'))
+    })
+
+    it('should resolve to false instead of propagating the error', () => {
+      return expect(openzeppelin.readynessProbe()).resolves.toBe(false)
+    })
+  })
+})

--- a/test/tests/ports/relay-router/relay-router-component.spec.ts
+++ b/test/tests/ports/relay-router/relay-router-component.spec.ts
@@ -1,0 +1,214 @@
+import { ILoggerComponent } from '@well-known-components/interfaces'
+import { IFeaturesComponent } from '@well-known-components/features-component/dist/types'
+import { ApplicationName } from '@well-known-components/features-component'
+import { Feature } from '../../../../src/ports/features'
+import { createRelayRouterComponent } from '../../../../src/ports/relay-router'
+import { IRelayRouterComponent } from '../../../../src/ports/relay-router/types'
+import {
+  IMetaTransactionProviderComponent,
+  TransactionData,
+} from '../../../../src/types/transactions/transactions'
+import { createCollection } from '../../../mocks/transactionData'
+
+let logs: ILoggerComponent
+let features: IFeaturesComponent
+let gelato: IMetaTransactionProviderComponent
+let openzeppelin: IMetaTransactionProviderComponent
+let transactionData: TransactionData
+let getFeatureVariantMock: jest.Mock
+let gelatoSendMock: jest.Mock
+let ozSendMock: jest.Mock
+
+beforeEach(() => {
+  transactionData = createCollection
+  getFeatureVariantMock = jest.fn()
+  gelatoSendMock = jest.fn()
+  ozSendMock = jest.fn()
+  logs = {
+    getLogger: () => ({
+      error: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      log: jest.fn(),
+      debug: jest.fn(),
+    }),
+  } as ILoggerComponent
+  features = {
+    getIsFeatureEnabled: jest.fn(),
+    getFeatureVariant: getFeatureVariantMock,
+    getEnvFeature: jest.fn(),
+  }
+  gelato = {
+    sendMetaTransaction: gelatoSendMock,
+    getNetworkGasPrice: jest.fn(),
+  }
+  openzeppelin = {
+    sendMetaTransaction: ozSendMock,
+    getNetworkGasPrice: jest.fn(),
+  }
+})
+
+afterEach(() => {
+  jest.restoreAllMocks()
+})
+
+describe('when creating the relay router', () => {
+  describe('and no providers are configured', () => {
+    it('should throw naming the env vars that enable each relayer', () => {
+      expect(() => createRelayRouterComponent({ logs, features })).toThrow(
+        'relay-router: no providers configured; set GELATO_API_KEY or OZ_RELAYER_URL to enable at least one relayer'
+      )
+    })
+  })
+})
+
+describe('when only gelato is configured', () => {
+  let router: IRelayRouterComponent
+
+  beforeEach(() => {
+    router = createRelayRouterComponent({ logs, features, gelato })
+  })
+
+  describe('and sending a meta transaction', () => {
+    beforeEach(() => {
+      gelatoSendMock.mockResolvedValueOnce('gelato-tx-hash')
+    })
+
+    it('should delegate to gelato and return its transaction hash', async () => {
+      await expect(router.sendMetaTransaction(transactionData)).resolves.toBe(
+        'gelato-tx-hash'
+      )
+      expect(gelatoSendMock).toHaveBeenCalledWith(transactionData)
+    })
+  })
+})
+
+describe('when only openzeppelin is configured', () => {
+  let router: IRelayRouterComponent
+
+  beforeEach(() => {
+    router = createRelayRouterComponent({ logs, features, openzeppelin })
+  })
+
+  describe('and sending a meta transaction', () => {
+    beforeEach(() => {
+      ozSendMock.mockResolvedValueOnce('oz-tx-hash')
+    })
+
+    it('should delegate to openzeppelin and return its transaction hash', async () => {
+      await expect(router.sendMetaTransaction(transactionData)).resolves.toBe(
+        'oz-tx-hash'
+      )
+      expect(ozSendMock).toHaveBeenCalledWith(transactionData)
+    })
+  })
+})
+
+describe('when both providers are configured', () => {
+  let router: IRelayRouterComponent
+
+  beforeEach(() => {
+    router = createRelayRouterComponent({
+      logs,
+      features,
+      gelato,
+      openzeppelin,
+    })
+  })
+
+  describe('and the feature flag variant selects gelato', () => {
+    beforeEach(() => {
+      getFeatureVariantMock.mockResolvedValueOnce({
+        name: Feature.RELAY_PROVIDER,
+        payload: { value: 'gelato' },
+      })
+      gelatoSendMock.mockResolvedValueOnce('gelato-tx-hash')
+    })
+
+    it('should look up the feature flag under the dapps application', async () => {
+      await router.sendMetaTransaction(transactionData)
+      expect(getFeatureVariantMock).toHaveBeenCalledWith(
+        ApplicationName.DAPPS,
+        Feature.RELAY_PROVIDER
+      )
+    })
+
+    it('should delegate to gelato and leave openzeppelin untouched', async () => {
+      await expect(router.sendMetaTransaction(transactionData)).resolves.toBe(
+        'gelato-tx-hash'
+      )
+      expect(gelatoSendMock).toHaveBeenCalledWith(transactionData)
+      expect(ozSendMock).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('and the feature flag variant selects openzeppelin', () => {
+    beforeEach(() => {
+      getFeatureVariantMock.mockResolvedValueOnce({
+        name: Feature.RELAY_PROVIDER,
+        payload: { value: 'openzeppelin' },
+      })
+      ozSendMock.mockResolvedValueOnce('oz-tx-hash')
+    })
+
+    it('should delegate to openzeppelin and leave gelato untouched', async () => {
+      await expect(router.sendMetaTransaction(transactionData)).resolves.toBe(
+        'oz-tx-hash'
+      )
+      expect(ozSendMock).toHaveBeenCalledWith(transactionData)
+      expect(gelatoSendMock).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('and the feature flag variant is "random"', () => {
+    beforeEach(() => {
+      getFeatureVariantMock.mockResolvedValueOnce({
+        name: Feature.RELAY_PROVIDER,
+        payload: { value: 'random' },
+      })
+      // Math.floor(0 * 2) === 0 -> picks the first available (gelato)
+      jest.spyOn(Math, 'random').mockReturnValue(0)
+      gelatoSendMock.mockResolvedValueOnce('gelato-tx-hash')
+    })
+
+    it('should pick a provider at random without honoring a specific name', async () => {
+      await expect(router.sendMetaTransaction(transactionData)).resolves.toBe(
+        'gelato-tx-hash'
+      )
+      expect(gelatoSendMock).toHaveBeenCalledWith(transactionData)
+    })
+  })
+
+  describe('and the feature flag asks for a provider that is not configured', () => {
+    beforeEach(() => {
+      getFeatureVariantMock.mockResolvedValueOnce({
+        name: Feature.RELAY_PROVIDER,
+        payload: { value: 'nonexistent' },
+      })
+      jest.spyOn(Math, 'random').mockReturnValue(0)
+      gelatoSendMock.mockResolvedValueOnce('gelato-tx-hash')
+    })
+
+    it('should fall back to a random configured provider instead of throwing', async () => {
+      await expect(router.sendMetaTransaction(transactionData)).resolves.toBe(
+        'gelato-tx-hash'
+      )
+    })
+  })
+
+  describe('and the feature flag lookup throws', () => {
+    beforeEach(() => {
+      getFeatureVariantMock.mockRejectedValueOnce(
+        new Error('feature flag service unavailable')
+      )
+      jest.spyOn(Math, 'random').mockReturnValue(0)
+      gelatoSendMock.mockResolvedValueOnce('gelato-tx-hash')
+    })
+
+    it('should fall back to a random configured provider instead of propagating the error', async () => {
+      await expect(router.sendMetaTransaction(transactionData)).resolves.toBe(
+        'gelato-tx-hash'
+      )
+    })
+  })
+})

--- a/test/tests/ports/transaction/checkGasPrice.spec.ts
+++ b/test/tests/ports/transaction/checkGasPrice.spec.ts
@@ -5,17 +5,19 @@ import {
 import { IFeaturesComponent } from '@well-known-components/features-component/dist/types'
 import { metricDeclarations } from '../../../../src/metrics'
 import { IContractsComponent } from '../../../../src/ports/contracts/types'
-import { GelatoMetaTransactionComponent } from '../../../../src/ports/gelato'
 import { checkGasPrice } from '../../../../src/ports/transaction/validation/checkGasPrice'
-import { TransactionData } from '../../../../src/types/transactions'
+import {
+  IMetaTransactionProviderComponent,
+  TransactionData,
+} from '../../../../src/types/transactions/transactions'
 import TransactionDataMock from '../../../mocks/transactionData'
 
 let transactionData: TransactionData
 let config: IConfigComponent
 let contracts: IContractsComponent
 let features: IFeaturesComponent
-let gelato: GelatoMetaTransactionComponent
-let gelatoGetNetworkGasPriceMock: jest.Mock
+let relayer: IMetaTransactionProviderComponent
+let relayerGetNetworkGasPriceMock: jest.Mock
 let getIsFeatureEnabledMock: jest.Mock
 let getFeatureVariantMock: jest.Mock
 let isCollectionAddressMock: jest.Mock
@@ -23,7 +25,7 @@ let components: {
   config: IConfigComponent
   contracts: IContractsComponent
   features: IFeaturesComponent
-  gelato: GelatoMetaTransactionComponent
+  relayer: IMetaTransactionProviderComponent
   metrics: IMetricsComponent<keyof typeof metricDeclarations>
 }
 
@@ -31,7 +33,7 @@ beforeEach(() => {
   isCollectionAddressMock = jest.fn()
   getIsFeatureEnabledMock = jest.fn()
   getFeatureVariantMock = jest.fn()
-  gelatoGetNetworkGasPriceMock = jest.fn()
+  relayerGetNetworkGasPriceMock = jest.fn()
   config = {
     requireString: async () => 'Sepolia',
     requireNumber: jest.fn(),
@@ -50,16 +52,16 @@ beforeEach(() => {
     getFeatureVariant: getFeatureVariantMock,
     getEnvFeature: jest.fn(),
   }
-  gelato = {
+  relayer = {
     sendMetaTransaction: jest.fn(),
-    getNetworkGasPrice: gelatoGetNetworkGasPriceMock,
+    getNetworkGasPrice: relayerGetNetworkGasPriceMock,
   }
 
   components = {
     config,
     contracts,
     features,
-    gelato,
+    relayer,
     metrics: {
       increment: jest.fn(),
     } as unknown as IMetricsComponent<keyof typeof metricDeclarations>,
@@ -89,7 +91,7 @@ describe('when checking the gas price for a txn', () => {
 
       describe('and the current network gas price is lower than max gas price allowed', () => {
         beforeEach(() => {
-          gelatoGetNetworkGasPriceMock.mockResolvedValueOnce(
+          relayerGetNetworkGasPriceMock.mockResolvedValueOnce(
             1000000000n
           )
         })
@@ -103,7 +105,7 @@ describe('when checking the gas price for a txn', () => {
 
       describe('and the current network gas price is greater than max gas price allowed', () => {
         beforeEach(() => {
-          gelatoGetNetworkGasPriceMock.mockResolvedValueOnce(
+          relayerGetNetworkGasPriceMock.mockResolvedValueOnce(
             2100000000n
           )
         })
@@ -127,7 +129,7 @@ describe('when checking the gas price for a txn', () => {
 
       describe('and the current network gas price could not be fetched', () => {
         beforeEach(() => {
-          gelatoGetNetworkGasPriceMock.mockRejectedValueOnce(new Error())
+          relayerGetNetworkGasPriceMock.mockRejectedValueOnce(new Error())
         })
 
         it('should throw an error', async () => {
@@ -157,7 +159,7 @@ describe('when checking the gas price for a txn', () => {
           },
           enabled: true,
         })
-        gelatoGetNetworkGasPriceMock.mockResolvedValueOnce(
+        relayerGetNetworkGasPriceMock.mockResolvedValueOnce(
           2100000000n
         )
       })

--- a/test/tests/ports/transaction/transaction-component.spec.ts
+++ b/test/tests/ports/transaction/transaction-component.spec.ts
@@ -8,23 +8,25 @@ import { IPgComponent } from '@well-known-components/pg-component'
 import { IFeaturesComponent } from '@well-known-components/features-component/dist/types'
 import { metricDeclarations } from '../../../../src/metrics'
 import { IContractsComponent } from '../../../../src/ports/contracts/types'
-import { GelatoMetaTransactionComponent } from '../../../../src/ports/gelato'
 import { createTransactionComponent } from '../../../../src/ports/transaction/component'
 import { ITransactionComponent } from '../../../../src/ports/transaction/types'
-import { TransactionData } from '../../../../src/types/transactions'
+import {
+  IMetaTransactionProviderComponent,
+  TransactionData,
+} from '../../../../src/types/transactions/transactions'
 
 let transaction: ITransactionComponent
 let fetcher: IFetchComponent
 let metrics: IMetricsComponent<keyof typeof metricDeclarations>
 let config: IConfigComponent
 let logs: ILoggerComponent
-let gelato: GelatoMetaTransactionComponent
+let relayer: IMetaTransactionProviderComponent
 let transactionData: TransactionData
 let contracts: IContractsComponent
 let pg: IPgComponent
 let features: IFeaturesComponent
 let mockedGetIsFeatureEnabled: jest.Mock
-let mockedGelatoSendMetaTransaction: jest.Mock
+let mockedRelayerSendMetaTransaction: jest.Mock
 let mockedQuery: jest.Mock
 
 beforeEach(() => {
@@ -32,11 +34,11 @@ beforeEach(() => {
   logs = {} as ILoggerComponent
   config = {} as IConfigComponent
   mockedGetIsFeatureEnabled = jest.fn()
-  mockedGelatoSendMetaTransaction = jest.fn()
+  mockedRelayerSendMetaTransaction = jest.fn()
   mockedQuery = jest.fn()
   transactionData = { from: '0x1', params: ['1', '2'] }
-  gelato = {
-    sendMetaTransaction: mockedGelatoSendMetaTransaction,
+  relayer = {
+    sendMetaTransaction: mockedRelayerSendMetaTransaction,
     getNetworkGasPrice: jest.fn(),
   }
   contracts = {} as IContractsComponent
@@ -58,7 +60,7 @@ beforeEach(() => {
     fetcher,
     metrics,
     logs,
-    gelato,
+    relayer,
     pg,
     contracts,
     features,
@@ -74,14 +76,14 @@ describe('when sending a transaction', () => {
 
   describe('and the request is successful', () => {
     beforeEach(() => {
-      mockedGelatoSendMetaTransaction.mockResolvedValueOnce(txHash)
+      mockedRelayerSendMetaTransaction.mockResolvedValueOnce(txHash)
     })
 
-    it('should send the transaction using gelato and resolve with its result', async () => {
+    it('should send the transaction using the relayer and resolve with its result', async () => {
       await expect(
         transaction.sendMetaTransaction(transactionData)
       ).resolves.toEqual(txHash)
-      expect(gelato.sendMetaTransaction).toHaveBeenCalledWith(transactionData)
+      expect(relayer.sendMetaTransaction).toHaveBeenCalledWith(transactionData)
     })
   })
 
@@ -89,7 +91,7 @@ describe('when sending a transaction', () => {
     let error: Error
     beforeEach(() => {
       error = new Error('Failed to send transaction')
-      mockedGelatoSendMetaTransaction.mockRejectedValueOnce(error)
+      mockedRelayerSendMetaTransaction.mockRejectedValueOnce(error)
     })
 
     it('should reject with the error', async () => {


### PR DESCRIPTION
Transaction consumers now depend on `relayer: IMetaTransactionProviderComponent` instead of `gelato`. The concrete `gelato` and `openzeppelin` components remain on AppComponents (both optional) for provider-specific capabilities. Provider selection in components.ts collapses to a single `createRelayRouterComponent` call, which already handles the "only one provider configured" and "none configured" cases.