### PR TITLE
feat: enhance OpenZeppelin relayer metrics for Gelato parity

### DIFF
--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -50,6 +50,16 @@ export const metricDeclarations = {
     type: IMetricsComponent.CounterType,
     labelNames: [],
   },
+  dcl_error_cancelled_transactions_openzeppelin: {
+    help: 'Count transactions cancelled by OpenZeppelin Relayer',
+    type: IMetricsComponent.CounterType,
+    labelNames: [],
+  },
+  dcl_error_reverted_transactions_openzeppelin: {
+    help: 'Count transactions reverted by OpenZeppelin Relayer',
+    type: IMetricsComponent.CounterType,
+    labelNames: [],
+  },
   dcl_error_service_errors_openzeppelin: {
     help: 'Count service errors when trying to relay a transaction to OpenZeppelin Relayer',
     type: IMetricsComponent.CounterType,
@@ -57,6 +67,16 @@ export const metricDeclarations = {
   },
   dcl_error_timeout_openzeppelin: {
     help: 'Count timeout errors when polling for a transaction hash from OpenZeppelin Relayer',
+    type: IMetricsComponent.CounterType,
+    labelNames: [],
+  },
+  dcl_error_no_balance_transactions_openzeppelin: {
+    help: 'Count errors of no balance when trying to relay a transaction to OpenZeppelin Relayer',
+    type: IMetricsComponent.CounterType,
+    labelNames: [],
+  },
+  dcl_error_high_gas_price_openzeppelin: {
+    help: 'Count errors when gas price exceeds allowed limit for OpenZeppelin Relayer transactions',
     type: IMetricsComponent.CounterType,
     labelNames: [],
   },

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -39,8 +39,8 @@ export const metricDeclarations = {
     type: IMetricsComponent.CounterType,
     labelNames: [],
   },
-  dcl_error_high_gas_price_gelato: {
-    help: 'Count errors when gas price exceeds allowed limit for Gelato transactions',
+  dcl_error_high_gas_price: {
+    help: 'Count transactions rejected because the network gas price exceeds the allowed limit',
     type: IMetricsComponent.CounterType,
     labelNames: [],
   },
@@ -75,16 +75,10 @@ export const metricDeclarations = {
     type: IMetricsComponent.CounterType,
     labelNames: [],
   },
-  dcl_error_high_gas_price_openzeppelin: {
-    help: 'Count errors when gas price exceeds allowed limit for OpenZeppelin Relayer transactions',
+  dcl_error_transaction_high_retries_openzeppelin: {
+    help: 'Count errors of transactions that exceeded the configured max retry threshold for OpenZeppelin Relayer.',
     type: IMetricsComponent.CounterType,
     labelNames: [],
-  },
-  dcl_oz_transaction_retries: {
-    help: 'Number of retries (replacement broadcasts) observed per OpenZeppelin transaction. Inferred client-side by counting distinct hashes seen for the same tx.id.',
-    type: IMetricsComponent.HistogramType,
-    labelNames: [],
-    buckets: [0, 1, 2, 3, 5, 10, 15, 20, 30, 50],
   },
   dcl_error_simulate_transaction: {
     help: 'Count errors of simulate transaction',

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -80,6 +80,12 @@ export const metricDeclarations = {
     type: IMetricsComponent.CounterType,
     labelNames: [],
   },
+  dcl_oz_transaction_retries: {
+    help: 'Number of retries (replacement broadcasts) observed per OpenZeppelin transaction. Inferred client-side by counting distinct hashes seen for the same tx.id.',
+    type: IMetricsComponent.HistogramType,
+    labelNames: [],
+    buckets: [0, 1, 2, 3, 5, 10, 15, 20, 30, 50],
+  },
   dcl_error_simulate_transaction: {
     help: 'Count errors of simulate transaction',
     type: IMetricsComponent.CounterType,

--- a/src/ports/openzeppelin/components.ts
+++ b/src/ports/openzeppelin/components.ts
@@ -21,6 +21,8 @@ type OZTransactionData = {
   hash: string | null
   status: string
   status_reason: string | null
+  nonce?: number
+  confirmed_at?: string | null
 }
 
 // Terminal transaction statuses that indicate the tx will never get a hash
@@ -54,6 +56,15 @@ export async function createOpenZeppelinComponent(
   const relayerId = await config.requireString('OZ_RELAYER_ID')
   const speed = (await config.getString('OZ_RELAYER_SPEED')) || 'fast'
   const rpcURL = await config.getString('RPC_URL')
+
+  const retryTrackIntervalMs =
+    (await config.getNumber('OZ_RETRY_TRACK_INTERVAL_MS')) ?? 5000
+  const retryTrackMaxDurationMs =
+    (await config.getNumber('OZ_RETRY_TRACK_MAX_DURATION_MS')) ?? 1800000
+  const retryWarnThreshold =
+    (await config.getNumber('OZ_RETRY_WARN_THRESHOLD')) ?? 10
+  const retryAlertThreshold =
+    (await config.getNumber('OZ_RETRY_ALERT_THRESHOLD')) ?? 20
 
   const authHeaders = {
     'Content-Type': 'application/json',
@@ -117,6 +128,82 @@ export async function createOpenZeppelinComponent(
 
     metrics.increment('dcl_error_timeout_openzeppelin')
     throw new RelayerTimeout('The limit of status checks was reached')
+  }
+
+  // Observe-only: counts how many times OZ replaces/bumps a transaction
+  // (each replacement broadcasts a new hash for the same tx.id) and emits
+  // a histogram observation when the tx settles. Never calls cancel/replace.
+  // Pollers die on process exit; that's acceptable for metrics.
+  async function trackTransactionRetries(
+    txId: string,
+    firstHash: string
+  ): Promise<void> {
+    const seen = new Set<string>([firstHash])
+    let retries = 0
+    let nonce: number | undefined
+    const deadline = Date.now() + retryTrackMaxDurationMs
+
+    try {
+      while (Date.now() < deadline) {
+        await new Promise((resolve) =>
+          setTimeout(resolve, retryTrackIntervalMs)
+        )
+
+        let response: any
+        try {
+          response = await fetcher.fetch(
+            `${relayerURL}/api/v1/relayers/${relayerId}/transactions/${txId}`,
+            { headers: authHeaders }
+          )
+        } catch (error) {
+          const message =
+            error instanceof Error ? error.message : 'Unknown error'
+          logger.warn(
+            `OpenZeppelin retry tracker fetch failed for ${txId}: ${message}`
+          )
+          continue
+        }
+
+        if (!response || !response.ok) continue
+
+        const { data } =
+          (await response.json()) as OZResponse<OZTransactionData>
+
+        if (!data) continue
+
+        if (typeof data.nonce === 'number') {
+          if (nonce === undefined) {
+            nonce = data.nonce
+          } else if (nonce !== data.nonce) {
+            logger.warn(
+              `OpenZeppelin retry tracker observed nonce change for ${txId}: ${nonce} -> ${data.nonce}; stopping`
+            )
+            break
+          }
+        }
+
+        if (data.hash && !seen.has(data.hash)) {
+          seen.add(data.hash)
+          retries++
+          if (retries === retryWarnThreshold) {
+            logger.warn(
+              `OpenZeppelin transaction ${txId} hit ${retryWarnThreshold} retries`
+            )
+          }
+          if (retries === retryAlertThreshold) {
+            logger.error(
+              `OpenZeppelin transaction ${txId} hit ${retryAlertThreshold} retries`
+            )
+          }
+        }
+
+        if (FAILED_STATUSES.has(data.status) || data.confirmed_at) {
+          break
+        }
+      }
+    } finally {
+      metrics.observe('dcl_oz_transaction_retries', {}, retries)
+    }
   }
 
   async function sendMetaTransaction(
@@ -183,6 +270,14 @@ export async function createOpenZeppelinComponent(
     logger.info(
       `OpenZeppelin relayed transaction ${txData.id} with hash ${hash}`
     )
+
+    trackTransactionRetries(txData.id, hash).catch((error) => {
+      const message = error instanceof Error ? error.message : 'Unknown error'
+      logger.warn(
+        `OpenZeppelin retry tracker for ${txData.id} crashed: ${message}`
+      )
+    })
+
     return hash
   }
 

--- a/src/ports/openzeppelin/components.ts
+++ b/src/ports/openzeppelin/components.ts
@@ -1,6 +1,7 @@
 import { createPublicClient, http } from 'viem'
 import { ErrorCode } from 'decentraland-transactions'
 import { AppComponents } from '../../types'
+import { sleep } from '../../logic/time'
 import {
   TransactionData,
   InvalidTransactionError,
@@ -21,12 +22,14 @@ type OZTransactionData = {
   hash: string | null
   status: string
   status_reason: string | null
-  nonce?: number
   confirmed_at?: string | null
 }
 
 // Terminal transaction statuses that indicate the tx will never get a hash
 const FAILED_STATUSES = new Set(['failed', 'invalid', 'cancelled'])
+
+const HASH_POLL_MAX_ATTEMPTS = 30
+const HASH_POLL_INTERVAL_MS = 2000
 
 const BALANCE_KEYWORDS = [
   'insufficient',
@@ -45,6 +48,14 @@ function containsAny(
   return keywords.some((kw) => lower.includes(kw))
 }
 
+const getErrorMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : 'Unknown error'
+
+const isRetryThresholdExceeded = (
+  seenHashes: Set<string>,
+  maxRetries: number
+): boolean => seenHashes.size - 1 > maxRetries
+
 export async function createOpenZeppelinComponent(
   components: Pick<AppComponents, 'config' | 'logs' | 'metrics' | 'fetcher'>
 ): Promise<OpenZeppelinMetaTransactionComponent> {
@@ -58,71 +69,85 @@ export async function createOpenZeppelinComponent(
   const rpcURL = await config.getString('RPC_URL')
 
   const retryTrackIntervalMs =
-    (await config.getNumber('OZ_RETRY_TRACK_INTERVAL_MS')) ?? 5000
+    (await config.getNumber('OZ_RETRY_TRACK_INTERVAL_MS')) ?? 5 * 1000
   const retryTrackMaxDurationMs =
-    (await config.getNumber('OZ_RETRY_TRACK_MAX_DURATION_MS')) ?? 1800000
-  const retryWarnThreshold =
-    (await config.getNumber('OZ_RETRY_WARN_THRESHOLD')) ?? 10
-  const retryAlertThreshold =
-    (await config.getNumber('OZ_RETRY_ALERT_THRESHOLD')) ?? 20
+    (await config.getNumber('OZ_RETRY_TRACK_MAX_DURATION_MS')) ?? 2 * 60 * 1000
+  const maxRetries = (await config.getNumber('OZ_MAX_RETRIES')) ?? 20
 
   const authHeaders = {
     'Content-Type': 'application/json',
     Authorization: `Bearer ${apiKey}`,
   }
 
-  async function pollForHash(txId: string): Promise<string> {
-    const maxAttempts = 30
-    const pollIntervalMs = 2000
+  // Shared polling loop for the OZ tx detail endpoint. Yields each parsed
+  // transaction so the caller drives its own exit conditions via plain
+  // return / throw — no callback ceremony.
+  async function* pollTransactionDetail(
+    txId: string,
+    options: {
+      maxAttempts: number
+      intervalMs: number
+      onError: (attempt: number, error: unknown) => void
+    }
+  ): AsyncGenerator<{ transaction: OZTransactionData; attempt: number }> {
+    const url = `${relayerURL}/api/v1/relayers/${relayerId}/transactions/${txId}`
 
-    for (let attempt = 0; attempt < maxAttempts; attempt++) {
-      await new Promise((resolve) => setTimeout(resolve, pollIntervalMs))
+    for (let attempt = 1; attempt <= options.maxAttempts; attempt++) {
+      await sleep(options.intervalMs)
 
       let response: any
       try {
-        response = await fetcher.fetch(
-          `${relayerURL}/api/v1/relayers/${relayerId}/transactions/${txId}`,
-          { headers: authHeaders }
-        )
-      } catch (error) {
-        const message = error instanceof Error ? error.message : 'Unknown error'
-        logger.error(
-          `OpenZeppelin poll attempt ${attempt + 1} failed: ${message}`
-        )
+        response = await fetcher.fetch(url, { headers: authHeaders })
+      } catch (error: unknown) {
+        options.onError(attempt, error)
         continue
       }
 
       if (!response.ok) continue
 
       const { data } = (await response.json()) as OZResponse<OZTransactionData>
-
       if (!data) continue
 
-      if (FAILED_STATUSES.has(data.status)) {
-        const reason = data.status_reason || data.status
+      yield { transaction: data, attempt }
+    }
+  }
+
+  async function pollForHash(txId: string): Promise<string> {
+    for await (const { transaction } of pollTransactionDetail(txId, {
+      maxAttempts: HASH_POLL_MAX_ATTEMPTS,
+      intervalMs: HASH_POLL_INTERVAL_MS,
+      onError: (attempt, error) =>
+        logger.error(
+          `OpenZeppelin poll attempt ${attempt} failed: ${getErrorMessage(
+            error
+          )}`
+        ),
+    })) {
+      if (FAILED_STATUSES.has(transaction.status)) {
+        const reason = transaction.status_reason || transaction.status
         logger.error(`OpenZeppelin transaction ${txId} failed: ${reason}`)
 
-        if (data.status === 'cancelled') {
+        if (transaction.status === 'cancelled') {
           metrics.increment('dcl_error_cancelled_transactions_openzeppelin')
-          if (containsAny(data.status_reason, BALANCE_KEYWORDS)) {
+          if (containsAny(transaction.status_reason, BALANCE_KEYWORDS)) {
             metrics.increment('dcl_error_no_balance_transactions_openzeppelin')
           }
-        } else if (containsAny(data.status_reason, REVERT_KEYWORDS)) {
+        } else if (containsAny(transaction.status_reason, REVERT_KEYWORDS)) {
           metrics.increment('dcl_error_reverted_transactions_openzeppelin')
-        } else if (containsAny(data.status_reason, BALANCE_KEYWORDS)) {
+        } else if (containsAny(transaction.status_reason, BALANCE_KEYWORDS)) {
           metrics.increment('dcl_error_no_balance_transactions_openzeppelin')
         } else {
           metrics.increment('dcl_error_service_errors_openzeppelin')
         }
 
         throw new InvalidTransactionError(
-          `Transaction ${data.status}: ${reason}`,
+          `Transaction ${transaction.status}: ${reason}`,
           ErrorCode.EXPECTATION_FAILED
         )
       }
 
-      if (data.hash) {
-        return data.hash
+      if (transaction.hash) {
+        return transaction.hash
       }
     }
 
@@ -130,79 +155,48 @@ export async function createOpenZeppelinComponent(
     throw new RelayerTimeout('The limit of status checks was reached')
   }
 
-  // Observe-only: counts how many times OZ replaces/bumps a transaction
-  // (each replacement broadcasts a new hash for the same tx.id) and emits
-  // a histogram observation when the tx settles. Never calls cancel/replace.
-  // Pollers die on process exit; that's acceptable for metrics.
-  async function trackTransactionRetries(
+  // Polls OZ to count transaction replacements.
+  // Every replacement generates a new hash for the same tx.id.
+  // Retry count = distinct hashes - 1.
+  // Read-only: never cancels or replaces transactions.
+  const trackTransactionRetries = async (
     txId: string,
     firstHash: string
-  ): Promise<void> {
-    const seen = new Set<string>([firstHash])
-    let retries = 0
-    let nonce: number | undefined
-    const deadline = Date.now() + retryTrackMaxDurationMs
+  ): Promise<void> => {
+    if (retryTrackIntervalMs <= 0 || retryTrackMaxDurationMs <= 0) {
+      logger.warn(
+        'OpenZeppelin retry tracker disabled due to invalid timing config'
+      )
+      return
+    }
 
-    try {
-      while (Date.now() < deadline) {
-        await new Promise((resolve) =>
-          setTimeout(resolve, retryTrackIntervalMs)
-        )
+    const seenHashes = new Set<string>([firstHash])
 
-        let response: any
-        try {
-          response = await fetcher.fetch(
-            `${relayerURL}/api/v1/relayers/${relayerId}/transactions/${txId}`,
-            { headers: authHeaders }
+    for await (const { transaction } of pollTransactionDetail(txId, {
+      maxAttempts: Math.ceil(retryTrackMaxDurationMs / retryTrackIntervalMs),
+      intervalMs: retryTrackIntervalMs,
+      onError: (attempt, error) =>
+        logger.warn(
+          `OpenZeppelin retry poll ${attempt} for ${txId} failed: ${getErrorMessage(
+            error
+          )}`
+        ),
+    })) {
+      if (transaction.hash) {
+        seenHashes.add(transaction.hash)
+
+        if (isRetryThresholdExceeded(seenHashes, maxRetries)) {
+          logger.error(
+            `OpenZeppelin transaction ${txId} exceeded ${maxRetries} retries`
           )
-        } catch (error) {
-          const message =
-            error instanceof Error ? error.message : 'Unknown error'
-          logger.warn(
-            `OpenZeppelin retry tracker fetch failed for ${txId}: ${message}`
-          )
-          continue
-        }
-
-        if (!response || !response.ok) continue
-
-        const { data } =
-          (await response.json()) as OZResponse<OZTransactionData>
-
-        if (!data) continue
-
-        if (typeof data.nonce === 'number') {
-          if (nonce === undefined) {
-            nonce = data.nonce
-          } else if (nonce !== data.nonce) {
-            logger.warn(
-              `OpenZeppelin retry tracker observed nonce change for ${txId}: ${nonce} -> ${data.nonce}; stopping`
-            )
-            break
-          }
-        }
-
-        if (data.hash && !seen.has(data.hash)) {
-          seen.add(data.hash)
-          retries++
-          if (retries === retryWarnThreshold) {
-            logger.warn(
-              `OpenZeppelin transaction ${txId} hit ${retryWarnThreshold} retries`
-            )
-          }
-          if (retries === retryAlertThreshold) {
-            logger.error(
-              `OpenZeppelin transaction ${txId} hit ${retryAlertThreshold} retries`
-            )
-          }
-        }
-
-        if (FAILED_STATUSES.has(data.status) || data.confirmed_at) {
-          break
+          metrics.increment('dcl_error_transaction_high_retries_openzeppelin')
+          return
         }
       }
-    } finally {
-      metrics.observe('dcl_oz_transaction_retries', {}, retries)
+
+      if (FAILED_STATUSES.has(transaction.status) || transaction.confirmed_at) {
+        return
+      }
     }
   }
 
@@ -223,8 +217,8 @@ export async function createOpenZeppelinComponent(
           body: JSON.stringify({ to, data, speed, value: '0x0' }),
         }
       )
-    } catch (error) {
-      const message = error instanceof Error ? error.message : 'Unknown error'
+    } catch (error: unknown) {
+      const message = getErrorMessage(error)
       logger.error(`OpenZeppelin failed to relay the transaction: ${message}`)
       metrics.increment('dcl_error_service_errors_openzeppelin')
       throw new RelayerError(500, message)
@@ -271,10 +265,11 @@ export async function createOpenZeppelinComponent(
       `OpenZeppelin relayed transaction ${txData.id} with hash ${hash}`
     )
 
-    trackTransactionRetries(txData.id, hash).catch((error) => {
-      const message = error instanceof Error ? error.message : 'Unknown error'
+    trackTransactionRetries(txData.id, hash).catch((error: unknown) => {
       logger.warn(
-        `OpenZeppelin retry tracker for ${txData.id} crashed: ${message}`
+        `OpenZeppelin retry tracker for ${txData.id} crashed: ${getErrorMessage(
+          error
+        )}`
       )
     })
 

--- a/src/ports/openzeppelin/components.ts
+++ b/src/ports/openzeppelin/components.ts
@@ -26,6 +26,23 @@ type OZTransactionData = {
 // Terminal transaction statuses that indicate the tx will never get a hash
 const FAILED_STATUSES = new Set(['failed', 'invalid', 'cancelled'])
 
+const BALANCE_KEYWORDS = [
+  'insufficient',
+  'balance',
+  'funds',
+  'no available token',
+]
+const REVERT_KEYWORDS = ['revert', 'reverted', 'execution reverted']
+
+function containsAny(
+  text: string | null | undefined,
+  keywords: string[]
+): boolean {
+  if (!text) return false
+  const lower = text.toLowerCase()
+  return keywords.some((kw) => lower.includes(kw))
+}
+
 export async function createOpenZeppelinComponent(
   components: Pick<AppComponents, 'config' | 'logs' | 'metrics' | 'fetcher'>
 ): Promise<OpenZeppelinMetaTransactionComponent> {
@@ -73,7 +90,20 @@ export async function createOpenZeppelinComponent(
       if (FAILED_STATUSES.has(data.status)) {
         const reason = data.status_reason || data.status
         logger.error(`OpenZeppelin transaction ${txId} failed: ${reason}`)
-        metrics.increment('dcl_error_service_errors_openzeppelin')
+
+        if (data.status === 'cancelled') {
+          metrics.increment('dcl_error_cancelled_transactions_openzeppelin')
+          if (containsAny(data.status_reason, BALANCE_KEYWORDS)) {
+            metrics.increment('dcl_error_no_balance_transactions_openzeppelin')
+          }
+        } else if (containsAny(data.status_reason, REVERT_KEYWORDS)) {
+          metrics.increment('dcl_error_reverted_transactions_openzeppelin')
+        } else if (containsAny(data.status_reason, BALANCE_KEYWORDS)) {
+          metrics.increment('dcl_error_no_balance_transactions_openzeppelin')
+        } else {
+          metrics.increment('dcl_error_service_errors_openzeppelin')
+        }
+
         throw new InvalidTransactionError(
           `Transaction ${data.status}: ${reason}`,
           ErrorCode.EXPECTATION_FAILED
@@ -119,6 +149,9 @@ export async function createOpenZeppelinComponent(
         `OpenZeppelin relayer responded with ${response.status}: ${body}`
       )
       metrics.increment('dcl_error_service_errors_openzeppelin')
+      if (containsAny(body, BALANCE_KEYWORDS)) {
+        metrics.increment('dcl_error_no_balance_transactions_openzeppelin')
+      }
 
       if (response.status === 422 || response.status === 400) {
         throw new InvalidTransactionError(body, ErrorCode.EXPECTATION_FAILED)
@@ -134,6 +167,9 @@ export async function createOpenZeppelinComponent(
 
     if (!success || !txData) {
       metrics.increment('dcl_error_service_errors_openzeppelin')
+      if (containsAny(error, BALANCE_KEYWORDS)) {
+        metrics.increment('dcl_error_no_balance_transactions_openzeppelin')
+      }
       throw new RelayerError(
         500,
         error || 'Unexpected response from OZ Relayer'

--- a/src/ports/relay-router/components.ts
+++ b/src/ports/relay-router/components.ts
@@ -6,7 +6,7 @@ import {
   TransactionData,
 } from '../../types/transactions/transactions'
 import { Feature } from '../features'
-import { IRelayRouterComponent } from './types'
+import { IRelayRouterComponent, ProviderName, ResolvedProvider } from './types'
 
 // Routes each transaction based on the 'relay-provider' feature flag variant.
 // Accepted variant payload.value:
@@ -22,21 +22,20 @@ export function createRelayRouterComponent(
   const { logs, features, gelato, openzeppelin } = components
   const logger = logs.getLogger('relay-router')
 
-  const available: Record<string, IMetaTransactionProviderComponent> = {}
+  const available: Partial<
+    Record<ProviderName, IMetaTransactionProviderComponent>
+  > = {}
   if (gelato) available.gelato = gelato
   if (openzeppelin) available.openzeppelin = openzeppelin
 
-  const availableNames = Object.keys(available)
+  const availableNames = Object.keys(available) as ProviderName[]
   if (availableNames.length === 0) {
     throw new Error(
       'relay-router: no providers configured; set GELATO_API_KEY or OZ_RELAYER_URL to enable at least one relayer'
     )
   }
 
-  async function resolveProvider(): Promise<{
-    name: string
-    provider: IMetaTransactionProviderComponent
-  }> {
+  async function resolveProvider(): Promise<ResolvedProvider> {
     let desired: string | undefined
     try {
       const variant = await features.getFeatureVariant(
@@ -49,11 +48,16 @@ export function createRelayRouterComponent(
       logger.warn(`relay-provider FF lookup failed, falling back: ${message}`)
     }
 
-    if (desired && desired !== 'random' && available[desired]) {
-      return { name: desired, provider: available[desired] }
+    if (desired && desired !== 'random' && available[desired as ProviderName]) {
+      const name = desired as ProviderName
+      return { name, provider: available[name]! }
     }
 
-    if (desired && desired !== 'random' && !available[desired]) {
+    if (
+      desired &&
+      desired !== 'random' &&
+      !available[desired as ProviderName]
+    ) {
       logger.warn(
         `relay-provider FF asked for "${desired}" but it is not configured; falling back to random`
       )
@@ -61,7 +65,7 @@ export function createRelayRouterComponent(
 
     const name =
       availableNames[Math.floor(Math.random() * availableNames.length)]
-    return { name, provider: available[name] }
+    return { name, provider: available[name]! }
   }
 
   const sendMetaTransaction = async (tx: TransactionData): Promise<string> => {
@@ -88,5 +92,6 @@ export function createRelayRouterComponent(
   return {
     sendMetaTransaction,
     getNetworkGasPrice,
+    resolveProvider,
   }
 }

--- a/src/ports/relay-router/types.ts
+++ b/src/ports/relay-router/types.ts
@@ -1,3 +1,12 @@
 import { IMetaTransactionProviderComponent } from '../../types/transactions/transactions'
 
-export type IRelayRouterComponent = IMetaTransactionProviderComponent
+export type ProviderName = 'gelato' | 'openzeppelin'
+
+export type ResolvedProvider = {
+  name: ProviderName
+  provider: IMetaTransactionProviderComponent
+}
+
+export type IRelayRouterComponent = IMetaTransactionProviderComponent & {
+  resolveProvider(): Promise<ResolvedProvider>
+}

--- a/src/ports/transaction/validation/checkGasPrice.ts
+++ b/src/ports/transaction/validation/checkGasPrice.ts
@@ -8,7 +8,6 @@ import {
 import { AppComponents } from '../../../types'
 import { Feature } from '../../features'
 import { HighCongestionError } from '../../../types/transactions/errors'
-import { metricDeclarations } from '../../../metrics'
 import { IGasPriceValidator } from './types'
 import { TransactionData } from '../../../types/transactions/transactions'
 
@@ -16,7 +15,7 @@ export const checkGasPrice: IGasPriceValidator = async (
   components,
   transactionData
 ) => {
-  const { config, features, metrics, relayer } = components
+  const { config, features, metrics } = components
   const chainName = (await config.requireString('CHAIN_NAME')) as ChainName
 
   const isGasPriceAllowedFFEnabled = await features.getIsFeatureEnabled(
@@ -45,10 +44,7 @@ export const checkGasPrice: IGasPriceValidator = async (
       }
 
       if (currentGasPrice > maxGasPriceAllowed) {
-        const { name: providerName } = await relayer.resolveProvider()
-        metrics.increment(
-          `dcl_error_high_gas_price_${providerName}` as keyof typeof metricDeclarations
-        )
+        metrics.increment('dcl_error_high_gas_price')
         throw new HighCongestionError(
           currentGasPrice.toString(),
           maxGasPriceAllowed.toString()

--- a/src/ports/transaction/validation/checkGasPrice.ts
+++ b/src/ports/transaction/validation/checkGasPrice.ts
@@ -8,6 +8,7 @@ import {
 import { AppComponents } from '../../../types'
 import { Feature } from '../../features'
 import { HighCongestionError } from '../../../types/transactions/errors'
+import { metricDeclarations } from '../../../metrics'
 import { IGasPriceValidator } from './types'
 import { TransactionData } from '../../../types/transactions/transactions'
 
@@ -15,7 +16,7 @@ export const checkGasPrice: IGasPriceValidator = async (
   components,
   transactionData
 ) => {
-  const { config, features, metrics } = components
+  const { config, features, metrics, relayer } = components
   const chainName = (await config.requireString('CHAIN_NAME')) as ChainName
 
   const isGasPriceAllowedFFEnabled = await features.getIsFeatureEnabled(
@@ -44,7 +45,10 @@ export const checkGasPrice: IGasPriceValidator = async (
       }
 
       if (currentGasPrice > maxGasPriceAllowed) {
-        metrics.increment('dcl_error_high_gas_price_gelato')
+        const { name: providerName } = await relayer.resolveProvider()
+        metrics.increment(
+          `dcl_error_high_gas_price_${providerName}` as keyof typeof metricDeclarations
+        )
         throw new HighCongestionError(
           currentGasPrice.toString(),
           maxGasPriceAllowed.toString()

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,7 +15,7 @@ import { IContractsComponent } from './ports/contracts/types'
 import { ITransactionComponent } from './ports/transaction/types'
 import { GelatoMetaTransactionComponent } from './ports/gelato'
 import { OpenZeppelinMetaTransactionComponent } from './ports/openzeppelin'
-import { IMetaTransactionProviderComponent } from './types/transactions/transactions'
+import { IRelayRouterComponent } from './ports/relay-router/types'
 
 export type GlobalContext = {
   components: AppComponents
@@ -25,7 +25,7 @@ export type BaseComponents = {
   config: IConfigComponent
   logs: ILoggerComponent
   globalLogger: ILoggerComponent.ILogger
-  relayer: IMetaTransactionProviderComponent
+  relayer: IRelayRouterComponent
   gelato?: GelatoMetaTransactionComponent
   openzeppelin?: OpenZeppelinMetaTransactionComponent
   features: IFeaturesComponent

--- a/test/tests/ports/gelato/gelato-component.spec.ts
+++ b/test/tests/ports/gelato/gelato-component.spec.ts
@@ -365,16 +365,3 @@ describe('when getting the network gas price', () => {
   })
 })
 
-describe('when gas price exceeds the allowed limit', () => {
-  it('should have the high gas price metric available', () => {
-    expect(metrics.increment).toBeDefined()
-  })
-
-  it('should be able to increment the high gas price metric with gas price values', () => {
-    metrics.increment('dcl_error_high_gas_price_gelato')
-
-    expect(metrics.increment).toHaveBeenCalledWith(
-      'dcl_error_high_gas_price_gelato'
-    )
-  })
-})

--- a/test/tests/ports/openzeppelin/openzeppelin-component.spec.ts
+++ b/test/tests/ports/openzeppelin/openzeppelin-component.spec.ts
@@ -238,6 +238,34 @@ describe('when sending a meta transaction', () => {
     })
   })
 
+  describe('and the relayer responds with a 422 status whose body mentions insufficient balance', () => {
+    beforeEach(() => {
+      fetchMock.mockResolvedValueOnce(
+        createResponse({
+          ok: false,
+          status: 422,
+          text: jest
+            .fn()
+            .mockResolvedValueOnce(
+              'insufficient balance to fund the transaction'
+            ),
+        })
+      )
+    })
+
+    it('should increment both service errors and no-balance metrics', async () => {
+      await expect(
+        openzeppelin.sendMetaTransaction(transactionData)
+      ).rejects.toThrow()
+      expect(metrics.increment).toHaveBeenCalledWith(
+        'dcl_error_service_errors_openzeppelin'
+      )
+      expect(metrics.increment).toHaveBeenCalledWith(
+        'dcl_error_no_balance_transactions_openzeppelin'
+      )
+    })
+  })
+
   describe('and the relayer responds with a 400 status', () => {
     beforeEach(() => {
       fetchMock.mockResolvedValueOnce(
@@ -303,6 +331,32 @@ describe('when sending a meta transaction', () => {
       ).rejects.toThrow()
       expect(metrics.increment).toHaveBeenCalledWith(
         'dcl_error_service_errors_openzeppelin'
+      )
+    })
+  })
+
+  describe('and the relayer responds with success=false carrying a balance error message', () => {
+    beforeEach(() => {
+      fetchMock.mockResolvedValueOnce(
+        createResponse({
+          json: jest.fn().mockResolvedValueOnce({
+            success: false,
+            data: null,
+            error: 'no available token balance to relay',
+          }),
+        })
+      )
+    })
+
+    it('should increment both service errors and no-balance metrics', async () => {
+      await expect(
+        openzeppelin.sendMetaTransaction(transactionData)
+      ).rejects.toThrow()
+      expect(metrics.increment).toHaveBeenCalledWith(
+        'dcl_error_service_errors_openzeppelin'
+      )
+      expect(metrics.increment).toHaveBeenCalledWith(
+        'dcl_error_no_balance_transactions_openzeppelin'
       )
     })
   })
@@ -385,7 +439,135 @@ describe('when sending a meta transaction', () => {
         )
       })
 
-      it('should increment the service errors metric', async () => {
+      it('should increment the reverted transactions metric', async () => {
+        const promise = openzeppelin.sendMetaTransaction(transactionData)
+        promise.catch(() => undefined)
+        await jest.advanceTimersByTimeAsync(2000)
+        await expect(promise).rejects.toThrow()
+        expect(metrics.increment).toHaveBeenCalledWith(
+          'dcl_error_reverted_transactions_openzeppelin'
+        )
+      })
+    })
+
+    describe('and polling the transaction returns a cancelled status without a balance reason', () => {
+      beforeEach(() => {
+        fetchMock.mockResolvedValueOnce(
+          createResponse({
+            json: jest.fn().mockResolvedValueOnce({
+              success: true,
+              data: {
+                id: 'oz-tx-id',
+                hash: null,
+                status: 'cancelled',
+                status_reason: 'user requested cancellation',
+              },
+              error: null,
+            }),
+          })
+        )
+      })
+
+      it('should increment only the cancelled transactions metric', async () => {
+        const promise = openzeppelin.sendMetaTransaction(transactionData)
+        promise.catch(() => undefined)
+        await jest.advanceTimersByTimeAsync(2000)
+        await expect(promise).rejects.toThrow()
+        expect(metrics.increment).toHaveBeenCalledWith(
+          'dcl_error_cancelled_transactions_openzeppelin'
+        )
+        expect(metrics.increment).not.toHaveBeenCalledWith(
+          'dcl_error_no_balance_transactions_openzeppelin'
+        )
+      })
+    })
+
+    describe('and polling the transaction returns a cancelled status with a balance reason', () => {
+      beforeEach(() => {
+        fetchMock.mockResolvedValueOnce(
+          createResponse({
+            json: jest.fn().mockResolvedValueOnce({
+              success: true,
+              data: {
+                id: 'oz-tx-id',
+                hash: null,
+                status: 'cancelled',
+                status_reason: 'insufficient balance to relay transaction',
+              },
+              error: null,
+            }),
+          })
+        )
+      })
+
+      it('should increment both the cancelled and no-balance metrics', async () => {
+        const promise = openzeppelin.sendMetaTransaction(transactionData)
+        promise.catch(() => undefined)
+        await jest.advanceTimersByTimeAsync(2000)
+        await expect(promise).rejects.toThrow()
+        expect(metrics.increment).toHaveBeenCalledWith(
+          'dcl_error_cancelled_transactions_openzeppelin'
+        )
+        expect(metrics.increment).toHaveBeenCalledWith(
+          'dcl_error_no_balance_transactions_openzeppelin'
+        )
+      })
+    })
+
+    describe('and polling the transaction returns a failed status with a balance reason', () => {
+      beforeEach(() => {
+        fetchMock.mockResolvedValueOnce(
+          createResponse({
+            json: jest.fn().mockResolvedValueOnce({
+              success: true,
+              data: {
+                id: 'oz-tx-id',
+                hash: null,
+                status: 'failed',
+                status_reason: 'insufficient funds for gas',
+              },
+              error: null,
+            }),
+          })
+        )
+      })
+
+      it('should increment only the no-balance metric', async () => {
+        const promise = openzeppelin.sendMetaTransaction(transactionData)
+        promise.catch(() => undefined)
+        await jest.advanceTimersByTimeAsync(2000)
+        await expect(promise).rejects.toThrow()
+        expect(metrics.increment).toHaveBeenCalledWith(
+          'dcl_error_no_balance_transactions_openzeppelin'
+        )
+        expect(metrics.increment).not.toHaveBeenCalledWith(
+          'dcl_error_reverted_transactions_openzeppelin'
+        )
+        expect(metrics.increment).not.toHaveBeenCalledWith(
+          'dcl_error_service_errors_openzeppelin'
+        )
+      })
+    })
+
+    describe('and polling the transaction returns an invalid status with an unmapped reason', () => {
+      beforeEach(() => {
+        fetchMock.mockResolvedValueOnce(
+          createResponse({
+            json: jest.fn().mockResolvedValueOnce({
+              success: true,
+              data: {
+                id: 'oz-tx-id',
+                hash: null,
+                status: 'invalid',
+                status_reason: 'something unexpected',
+              },
+              error: null,
+            }),
+          })
+        )
+      })
+
+      it('should fall back to the service errors metric', async () => {
         const promise = openzeppelin.sendMetaTransaction(transactionData)
         promise.catch(() => undefined)
         await jest.advanceTimersByTimeAsync(2000)
@@ -489,4 +671,3 @@ describe('when RPC_URL is not configured', () => {
     })
   })
 })
-

--- a/test/tests/ports/openzeppelin/openzeppelin-component.spec.ts
+++ b/test/tests/ports/openzeppelin/openzeppelin-component.spec.ts
@@ -60,6 +60,10 @@ let getStringMock: jest.Mock
 let transactionData: TransactionData
 
 beforeEach(async () => {
+  // Fake timers globally so the fire-and-forget retry tracker (started by
+  // sendMetaTransaction) never schedules a real setTimeout that would leak
+  // across tests.
+  jest.useFakeTimers()
   mockGetGasPrice.mockReset()
   fetchMock = jest.fn()
   getStringMock = jest.fn(async (key: string) => {
@@ -119,6 +123,7 @@ beforeEach(async () => {
 })
 
 afterEach(() => {
+  jest.useRealTimers()
   jest.restoreAllMocks()
 })
 
@@ -616,6 +621,334 @@ describe('when sending a meta transaction', () => {
           'dcl_error_timeout_openzeppelin'
         )
       })
+    })
+  })
+})
+
+describe('when tracking retries for an OpenZeppelin transaction', () => {
+  const TX_ID = 'oz-tx-id'
+  const FIRST_HASH = '0xfirstHash'
+  const TX_DETAIL_ENDPOINT = `${TX_ENDPOINT}/${TX_ID}`
+
+  function postResponseWithHash(hash: string | null) {
+    return createResponse({
+      json: jest.fn().mockResolvedValueOnce({
+        success: true,
+        data: {
+          id: TX_ID,
+          hash,
+          status: 'submitted',
+          status_reason: null,
+        },
+        error: null,
+      }),
+    })
+  }
+
+  function pollResponse(data: {
+    hash?: string | null
+    status?: string
+    status_reason?: string | null
+    nonce?: number
+    confirmed_at?: string | null
+  }) {
+    return createResponse({
+      json: jest.fn().mockResolvedValueOnce({
+        success: true,
+        data: {
+          id: TX_ID,
+          hash: data.hash ?? null,
+          status: data.status ?? 'submitted',
+          status_reason: data.status_reason ?? null,
+          ...(data.nonce !== undefined ? { nonce: data.nonce } : {}),
+          ...(data.confirmed_at !== undefined
+            ? { confirmed_at: data.confirmed_at }
+            : {}),
+        },
+        error: null,
+      }),
+    })
+  }
+
+  describe('and the relayer reports two new hashes before confirming on chain', () => {
+    beforeEach(() => {
+      fetchMock.mockResolvedValueOnce(postResponseWithHash(FIRST_HASH))
+      fetchMock.mockResolvedValueOnce(pollResponse({ hash: '0xsecondHash' }))
+      fetchMock.mockResolvedValueOnce(pollResponse({ hash: '0xthirdHash' }))
+      fetchMock.mockResolvedValueOnce(
+        pollResponse({
+          hash: '0xthirdHash',
+          confirmed_at: '2026-01-01T00:00:00Z',
+        })
+      )
+    })
+
+    it('should observe the retries histogram with the count of distinct hashes minus one', async () => {
+      await openzeppelin.sendMetaTransaction(transactionData)
+      await jest.advanceTimersByTimeAsync(5000 * 3)
+      expect(metrics.observe).toHaveBeenCalledWith(
+        'dcl_oz_transaction_retries',
+        {},
+        2
+      )
+    })
+
+    it('should poll the transaction detail endpoint with the bearer token', async () => {
+      await openzeppelin.sendMetaTransaction(transactionData)
+      await jest.advanceTimersByTimeAsync(5000)
+      expect(fetchMock).toHaveBeenCalledWith(
+        TX_DETAIL_ENDPOINT,
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: 'Bearer api-key',
+          }),
+        })
+      )
+    })
+  })
+
+  describe('and the relayer keeps reporting the same hash', () => {
+    beforeEach(() => {
+      fetchMock.mockResolvedValueOnce(postResponseWithHash(FIRST_HASH))
+      fetchMock.mockResolvedValue(
+        pollResponse({
+          hash: FIRST_HASH,
+          confirmed_at: '2026-01-01T00:00:00Z',
+        })
+      )
+    })
+
+    it('should observe zero retries', async () => {
+      await openzeppelin.sendMetaTransaction(transactionData)
+      await jest.advanceTimersByTimeAsync(5000)
+      expect(metrics.observe).toHaveBeenCalledWith(
+        'dcl_oz_transaction_retries',
+        {},
+        0
+      )
+    })
+  })
+
+  describe('and the relayer settles into a terminal failed status', () => {
+    beforeEach(() => {
+      fetchMock.mockResolvedValueOnce(postResponseWithHash(FIRST_HASH))
+      fetchMock.mockResolvedValueOnce(
+        pollResponse({ hash: '0xreplaced', status: 'failed' })
+      )
+    })
+
+    it('should stop polling and observe one retry', async () => {
+      await openzeppelin.sendMetaTransaction(transactionData)
+      await jest.advanceTimersByTimeAsync(5000)
+      expect(metrics.observe).toHaveBeenCalledWith(
+        'dcl_oz_transaction_retries',
+        {},
+        1
+      )
+      const callsBeforeStop = fetchMock.mock.calls.length
+      await jest.advanceTimersByTimeAsync(5000 * 5)
+      expect(fetchMock.mock.calls.length).toBe(callsBeforeStop)
+    })
+  })
+
+  describe('and the same nonce is observed across polls', () => {
+    beforeEach(() => {
+      fetchMock.mockResolvedValueOnce(postResponseWithHash(FIRST_HASH))
+      fetchMock.mockResolvedValueOnce(
+        pollResponse({ hash: '0xsecondHash', nonce: 42 })
+      )
+      fetchMock.mockResolvedValueOnce(
+        pollResponse({
+          hash: '0xthirdHash',
+          nonce: 42,
+          confirmed_at: '2026-01-01T00:00:00Z',
+        })
+      )
+    })
+
+    it('should keep counting hashes as retries', async () => {
+      await openzeppelin.sendMetaTransaction(transactionData)
+      await jest.advanceTimersByTimeAsync(5000 * 2)
+      expect(metrics.observe).toHaveBeenCalledWith(
+        'dcl_oz_transaction_retries',
+        {},
+        2
+      )
+    })
+  })
+
+  describe('and the nonce changes across polls', () => {
+    beforeEach(() => {
+      fetchMock.mockResolvedValueOnce(postResponseWithHash(FIRST_HASH))
+      fetchMock.mockResolvedValueOnce(
+        pollResponse({ hash: '0xsecondHash', nonce: 42 })
+      )
+      fetchMock.mockResolvedValueOnce(
+        pollResponse({ hash: '0xthirdHash', nonce: 99 })
+      )
+    })
+
+    it('should stop tracking with the retries observed up to that point', async () => {
+      await openzeppelin.sendMetaTransaction(transactionData)
+      await jest.advanceTimersByTimeAsync(5000 * 2)
+      expect(metrics.observe).toHaveBeenCalledWith(
+        'dcl_oz_transaction_retries',
+        {},
+        1
+      )
+    })
+  })
+
+  describe('and the retry count crosses the warn threshold', () => {
+    let logger: { warn: jest.Mock; error: jest.Mock; info: jest.Mock }
+
+    beforeEach(async () => {
+      logger = {
+        warn: jest.fn(),
+        error: jest.fn(),
+        info: jest.fn(),
+      }
+      logs = {
+        getLogger: () =>
+          ({
+            ...logger,
+            log: jest.fn(),
+            debug: jest.fn(),
+          } as ReturnType<ILoggerComponent['getLogger']>),
+      } as ILoggerComponent
+      ;(config.getNumber as jest.Mock).mockImplementation(
+        async (key: string) => {
+          if (key === 'OZ_RETRY_WARN_THRESHOLD') return 2
+          if (key === 'OZ_RETRY_ALERT_THRESHOLD') return 4
+          return undefined
+        }
+      )
+      openzeppelin = await createOpenZeppelinComponent({
+        config,
+        logs,
+        metrics,
+        fetcher,
+      })
+      fetchMock.mockResolvedValueOnce(postResponseWithHash(FIRST_HASH))
+      fetchMock.mockResolvedValueOnce(pollResponse({ hash: '0xb' }))
+      fetchMock.mockResolvedValueOnce(
+        pollResponse({
+          hash: '0xc',
+          confirmed_at: '2026-01-01T00:00:00Z',
+        })
+      )
+    })
+
+    it('should log a warning naming the threshold', async () => {
+      await openzeppelin.sendMetaTransaction(transactionData)
+      await jest.advanceTimersByTimeAsync(5000 * 2)
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining(`${TX_ID} hit 2 retries`)
+      )
+      expect(logger.error).not.toHaveBeenCalledWith(
+        expect.stringContaining('hit 4 retries')
+      )
+    })
+  })
+
+  describe('and the retry count crosses the alert threshold', () => {
+    let logger: { warn: jest.Mock; error: jest.Mock; info: jest.Mock }
+
+    beforeEach(async () => {
+      logger = {
+        warn: jest.fn(),
+        error: jest.fn(),
+        info: jest.fn(),
+      }
+      logs = {
+        getLogger: () =>
+          ({
+            ...logger,
+            log: jest.fn(),
+            debug: jest.fn(),
+          } as ReturnType<ILoggerComponent['getLogger']>),
+      } as ILoggerComponent
+      ;(config.getNumber as jest.Mock).mockImplementation(
+        async (key: string) => {
+          if (key === 'OZ_RETRY_WARN_THRESHOLD') return 1
+          if (key === 'OZ_RETRY_ALERT_THRESHOLD') return 2
+          return undefined
+        }
+      )
+      openzeppelin = await createOpenZeppelinComponent({
+        config,
+        logs,
+        metrics,
+        fetcher,
+      })
+      fetchMock.mockResolvedValueOnce(postResponseWithHash(FIRST_HASH))
+      fetchMock.mockResolvedValueOnce(pollResponse({ hash: '0xb' }))
+      fetchMock.mockResolvedValueOnce(
+        pollResponse({
+          hash: '0xc',
+          confirmed_at: '2026-01-01T00:00:00Z',
+        })
+      )
+    })
+
+    it('should log an error naming the alert threshold', async () => {
+      await openzeppelin.sendMetaTransaction(transactionData)
+      await jest.advanceTimersByTimeAsync(5000 * 2)
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining(`${TX_ID} hit 2 retries`)
+      )
+    })
+  })
+
+  describe('and a poll request rejects with a network error', () => {
+    beforeEach(() => {
+      fetchMock.mockResolvedValueOnce(postResponseWithHash(FIRST_HASH))
+      fetchMock.mockRejectedValueOnce(new Error('connection reset'))
+      fetchMock.mockResolvedValueOnce(
+        pollResponse({
+          hash: '0xrecovered',
+          confirmed_at: '2026-01-01T00:00:00Z',
+        })
+      )
+    })
+
+    it('should swallow the error and keep polling on the next tick', async () => {
+      await openzeppelin.sendMetaTransaction(transactionData)
+      await jest.advanceTimersByTimeAsync(5000 * 2)
+      expect(metrics.observe).toHaveBeenCalledWith(
+        'dcl_oz_transaction_retries',
+        {},
+        1
+      )
+    })
+  })
+
+  describe('and the hash never changes nor settles', () => {
+    beforeEach(() => {
+      fetchMock.mockResolvedValueOnce(postResponseWithHash(FIRST_HASH))
+      fetchMock.mockResolvedValue(pollResponse({ hash: FIRST_HASH }))
+    })
+
+    it('should stop tracking after the configured TTL', async () => {
+      await openzeppelin.sendMetaTransaction(transactionData)
+      await jest.advanceTimersByTimeAsync(1800000)
+      expect(metrics.observe).toHaveBeenCalledWith(
+        'dcl_oz_transaction_retries',
+        {},
+        0
+      )
+    })
+  })
+
+  describe('and sendMetaTransaction has just returned the first hash', () => {
+    beforeEach(() => {
+      fetchMock.mockResolvedValueOnce(postResponseWithHash(FIRST_HASH))
+      fetchMock.mockResolvedValue(pollResponse({ hash: FIRST_HASH }))
+    })
+
+    it('should not have observed the retries histogram yet', async () => {
+      await openzeppelin.sendMetaTransaction(transactionData)
+      expect(metrics.observe).not.toHaveBeenCalled()
     })
   })
 })

--- a/test/tests/ports/openzeppelin/openzeppelin-component.spec.ts
+++ b/test/tests/ports/openzeppelin/openzeppelin-component.spec.ts
@@ -649,7 +649,6 @@ describe('when tracking retries for an OpenZeppelin transaction', () => {
     hash?: string | null
     status?: string
     status_reason?: string | null
-    nonce?: number
     confirmed_at?: string | null
   }) {
     return createResponse({
@@ -660,7 +659,6 @@ describe('when tracking retries for an OpenZeppelin transaction', () => {
           hash: data.hash ?? null,
           status: data.status ?? 'submitted',
           status_reason: data.status_reason ?? null,
-          ...(data.nonce !== undefined ? { nonce: data.nonce } : {}),
           ...(data.confirmed_at !== undefined
             ? { confirmed_at: data.confirmed_at }
             : {}),
@@ -674,22 +672,11 @@ describe('when tracking retries for an OpenZeppelin transaction', () => {
     beforeEach(() => {
       fetchMock.mockResolvedValueOnce(postResponseWithHash(FIRST_HASH))
       fetchMock.mockResolvedValueOnce(pollResponse({ hash: '0xsecondHash' }))
-      fetchMock.mockResolvedValueOnce(pollResponse({ hash: '0xthirdHash' }))
       fetchMock.mockResolvedValueOnce(
         pollResponse({
           hash: '0xthirdHash',
           confirmed_at: '2026-01-01T00:00:00Z',
         })
-      )
-    })
-
-    it('should observe the retries histogram with the count of distinct hashes minus one', async () => {
-      await openzeppelin.sendMetaTransaction(transactionData)
-      await jest.advanceTimersByTimeAsync(5000 * 3)
-      expect(metrics.observe).toHaveBeenCalledWith(
-        'dcl_oz_transaction_retries',
-        {},
-        2
       )
     })
 
@@ -705,6 +692,14 @@ describe('when tracking retries for an OpenZeppelin transaction', () => {
         })
       )
     })
+
+    it('should not increment the high-retries counter when below the threshold', async () => {
+      await openzeppelin.sendMetaTransaction(transactionData)
+      await jest.advanceTimersByTimeAsync(5000 * 2)
+      expect(metrics.increment).not.toHaveBeenCalledWith(
+        'dcl_error_transaction_high_retries_openzeppelin'
+      )
+    })
   })
 
   describe('and the relayer keeps reporting the same hash', () => {
@@ -718,13 +713,11 @@ describe('when tracking retries for an OpenZeppelin transaction', () => {
       )
     })
 
-    it('should observe zero retries', async () => {
+    it('should not increment the high-retries counter', async () => {
       await openzeppelin.sendMetaTransaction(transactionData)
       await jest.advanceTimersByTimeAsync(5000)
-      expect(metrics.observe).toHaveBeenCalledWith(
-        'dcl_oz_transaction_retries',
-        {},
-        0
+      expect(metrics.increment).not.toHaveBeenCalledWith(
+        'dcl_error_transaction_high_retries_openzeppelin'
       )
     })
   })
@@ -737,69 +730,19 @@ describe('when tracking retries for an OpenZeppelin transaction', () => {
       )
     })
 
-    it('should stop polling and observe one retry', async () => {
+    it('should stop polling without incrementing the high-retries counter', async () => {
       await openzeppelin.sendMetaTransaction(transactionData)
       await jest.advanceTimersByTimeAsync(5000)
-      expect(metrics.observe).toHaveBeenCalledWith(
-        'dcl_oz_transaction_retries',
-        {},
-        1
-      )
       const callsBeforeStop = fetchMock.mock.calls.length
       await jest.advanceTimersByTimeAsync(5000 * 5)
       expect(fetchMock.mock.calls.length).toBe(callsBeforeStop)
-    })
-  })
-
-  describe('and the same nonce is observed across polls', () => {
-    beforeEach(() => {
-      fetchMock.mockResolvedValueOnce(postResponseWithHash(FIRST_HASH))
-      fetchMock.mockResolvedValueOnce(
-        pollResponse({ hash: '0xsecondHash', nonce: 42 })
-      )
-      fetchMock.mockResolvedValueOnce(
-        pollResponse({
-          hash: '0xthirdHash',
-          nonce: 42,
-          confirmed_at: '2026-01-01T00:00:00Z',
-        })
-      )
-    })
-
-    it('should keep counting hashes as retries', async () => {
-      await openzeppelin.sendMetaTransaction(transactionData)
-      await jest.advanceTimersByTimeAsync(5000 * 2)
-      expect(metrics.observe).toHaveBeenCalledWith(
-        'dcl_oz_transaction_retries',
-        {},
-        2
+      expect(metrics.increment).not.toHaveBeenCalledWith(
+        'dcl_error_transaction_high_retries_openzeppelin'
       )
     })
   })
 
-  describe('and the nonce changes across polls', () => {
-    beforeEach(() => {
-      fetchMock.mockResolvedValueOnce(postResponseWithHash(FIRST_HASH))
-      fetchMock.mockResolvedValueOnce(
-        pollResponse({ hash: '0xsecondHash', nonce: 42 })
-      )
-      fetchMock.mockResolvedValueOnce(
-        pollResponse({ hash: '0xthirdHash', nonce: 99 })
-      )
-    })
-
-    it('should stop tracking with the retries observed up to that point', async () => {
-      await openzeppelin.sendMetaTransaction(transactionData)
-      await jest.advanceTimersByTimeAsync(5000 * 2)
-      expect(metrics.observe).toHaveBeenCalledWith(
-        'dcl_oz_transaction_retries',
-        {},
-        1
-      )
-    })
-  })
-
-  describe('and the retry count crosses the warn threshold', () => {
+  describe('and the retry count exceeds the configured maximum', () => {
     let logger: { warn: jest.Mock; error: jest.Mock; info: jest.Mock }
 
     beforeEach(async () => {
@@ -818,8 +761,7 @@ describe('when tracking retries for an OpenZeppelin transaction', () => {
       } as ILoggerComponent
       ;(config.getNumber as jest.Mock).mockImplementation(
         async (key: string) => {
-          if (key === 'OZ_RETRY_WARN_THRESHOLD') return 2
-          if (key === 'OZ_RETRY_ALERT_THRESHOLD') return 4
+          if (key === 'OZ_MAX_RETRIES') return 2
           return undefined
         }
       )
@@ -829,74 +771,36 @@ describe('when tracking retries for an OpenZeppelin transaction', () => {
         metrics,
         fetcher,
       })
+      // FIRST_HASH (initial), 0xb (retry 1), 0xc (retry 2), 0xd (retry 3 → exceeds max=2)
       fetchMock.mockResolvedValueOnce(postResponseWithHash(FIRST_HASH))
       fetchMock.mockResolvedValueOnce(pollResponse({ hash: '0xb' }))
-      fetchMock.mockResolvedValueOnce(
-        pollResponse({
-          hash: '0xc',
-          confirmed_at: '2026-01-01T00:00:00Z',
-        })
-      )
+      fetchMock.mockResolvedValueOnce(pollResponse({ hash: '0xc' }))
+      fetchMock.mockResolvedValueOnce(pollResponse({ hash: '0xd' }))
     })
 
-    it('should log a warning naming the threshold', async () => {
+    it('should increment the high-retries counter exactly once', async () => {
       await openzeppelin.sendMetaTransaction(transactionData)
-      await jest.advanceTimersByTimeAsync(5000 * 2)
-      expect(logger.warn).toHaveBeenCalledWith(
-        expect.stringContaining(`${TX_ID} hit 2 retries`)
+      await jest.advanceTimersByTimeAsync(5000 * 3)
+      const calls = (metrics.increment as jest.Mock).mock.calls.filter(
+        ([name]) => name === 'dcl_error_transaction_high_retries_openzeppelin'
       )
-      expect(logger.error).not.toHaveBeenCalledWith(
-        expect.stringContaining('hit 4 retries')
-      )
-    })
-  })
-
-  describe('and the retry count crosses the alert threshold', () => {
-    let logger: { warn: jest.Mock; error: jest.Mock; info: jest.Mock }
-
-    beforeEach(async () => {
-      logger = {
-        warn: jest.fn(),
-        error: jest.fn(),
-        info: jest.fn(),
-      }
-      logs = {
-        getLogger: () =>
-          ({
-            ...logger,
-            log: jest.fn(),
-            debug: jest.fn(),
-          } as ReturnType<ILoggerComponent['getLogger']>),
-      } as ILoggerComponent
-      ;(config.getNumber as jest.Mock).mockImplementation(
-        async (key: string) => {
-          if (key === 'OZ_RETRY_WARN_THRESHOLD') return 1
-          if (key === 'OZ_RETRY_ALERT_THRESHOLD') return 2
-          return undefined
-        }
-      )
-      openzeppelin = await createOpenZeppelinComponent({
-        config,
-        logs,
-        metrics,
-        fetcher,
-      })
-      fetchMock.mockResolvedValueOnce(postResponseWithHash(FIRST_HASH))
-      fetchMock.mockResolvedValueOnce(pollResponse({ hash: '0xb' }))
-      fetchMock.mockResolvedValueOnce(
-        pollResponse({
-          hash: '0xc',
-          confirmed_at: '2026-01-01T00:00:00Z',
-        })
-      )
+      expect(calls).toHaveLength(1)
     })
 
-    it('should log an error naming the alert threshold', async () => {
+    it('should log an error naming the maximum and the transaction id', async () => {
       await openzeppelin.sendMetaTransaction(transactionData)
-      await jest.advanceTimersByTimeAsync(5000 * 2)
+      await jest.advanceTimersByTimeAsync(5000 * 3)
       expect(logger.error).toHaveBeenCalledWith(
-        expect.stringContaining(`${TX_ID} hit 2 retries`)
+        expect.stringContaining(`${TX_ID} exceeded 2 retries`)
       )
+    })
+
+    it('should stop polling after the alert fires', async () => {
+      await openzeppelin.sendMetaTransaction(transactionData)
+      await jest.advanceTimersByTimeAsync(5000 * 3)
+      const callsAfterAlert = fetchMock.mock.calls.length
+      await jest.advanceTimersByTimeAsync(5000 * 5)
+      expect(fetchMock.mock.calls.length).toBe(callsAfterAlert)
     })
   })
 
@@ -915,10 +819,9 @@ describe('when tracking retries for an OpenZeppelin transaction', () => {
     it('should swallow the error and keep polling on the next tick', async () => {
       await openzeppelin.sendMetaTransaction(transactionData)
       await jest.advanceTimersByTimeAsync(5000 * 2)
-      expect(metrics.observe).toHaveBeenCalledWith(
-        'dcl_oz_transaction_retries',
-        {},
-        1
+      expect(fetchMock).toHaveBeenCalledTimes(3)
+      expect(metrics.increment).not.toHaveBeenCalledWith(
+        'dcl_error_transaction_high_retries_openzeppelin'
       )
     })
   })
@@ -929,13 +832,14 @@ describe('when tracking retries for an OpenZeppelin transaction', () => {
       fetchMock.mockResolvedValue(pollResponse({ hash: FIRST_HASH }))
     })
 
-    it('should stop tracking after the configured TTL', async () => {
+    it('should stop tracking after the configured TTL without alerting', async () => {
       await openzeppelin.sendMetaTransaction(transactionData)
       await jest.advanceTimersByTimeAsync(1800000)
-      expect(metrics.observe).toHaveBeenCalledWith(
-        'dcl_oz_transaction_retries',
-        {},
-        0
+      const callsAtDeadline = fetchMock.mock.calls.length
+      await jest.advanceTimersByTimeAsync(5000 * 5)
+      expect(fetchMock.mock.calls.length).toBe(callsAtDeadline)
+      expect(metrics.increment).not.toHaveBeenCalledWith(
+        'dcl_error_transaction_high_retries_openzeppelin'
       )
     })
   })
@@ -946,9 +850,12 @@ describe('when tracking retries for an OpenZeppelin transaction', () => {
       fetchMock.mockResolvedValue(pollResponse({ hash: FIRST_HASH }))
     })
 
-    it('should not have observed the retries histogram yet', async () => {
+    it('should not have polled the tracker endpoint yet', async () => {
       await openzeppelin.sendMetaTransaction(transactionData)
-      expect(metrics.observe).not.toHaveBeenCalled()
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+      expect(metrics.increment).not.toHaveBeenCalledWith(
+        'dcl_error_transaction_high_retries_openzeppelin'
+      )
     })
   })
 })

--- a/test/tests/ports/relay-router/relay-router-component.spec.ts
+++ b/test/tests/ports/relay-router/relay-router-component.spec.ts
@@ -211,4 +211,48 @@ describe('when both providers are configured', () => {
       )
     })
   })
+
+  describe('and a caller asks the router which provider would handle the next transaction', () => {
+    describe('and the feature flag selects gelato', () => {
+      beforeEach(() => {
+        getFeatureVariantMock.mockResolvedValueOnce({
+          name: Feature.RELAY_PROVIDER,
+          payload: { value: 'gelato' },
+        })
+      })
+
+      it('should resolve to the gelato provider', async () => {
+        const resolved = await router.resolveProvider()
+        expect(resolved.name).toBe('gelato')
+        expect(resolved.provider).toBe(gelato)
+      })
+    })
+
+    describe('and the feature flag selects openzeppelin', () => {
+      beforeEach(() => {
+        getFeatureVariantMock.mockResolvedValueOnce({
+          name: Feature.RELAY_PROVIDER,
+          payload: { value: 'openzeppelin' },
+        })
+      })
+
+      it('should resolve to the openzeppelin provider', async () => {
+        const resolved = await router.resolveProvider()
+        expect(resolved.name).toBe('openzeppelin')
+        expect(resolved.provider).toBe(openzeppelin)
+      })
+    })
+
+    describe('and the feature flag is missing', () => {
+      beforeEach(() => {
+        getFeatureVariantMock.mockResolvedValueOnce(undefined)
+        jest.spyOn(Math, 'random').mockReturnValue(0)
+      })
+
+      it('should resolve to one of the configured providers', async () => {
+        const resolved = await router.resolveProvider()
+        expect(['gelato', 'openzeppelin']).toContain(resolved.name)
+      })
+    })
+  })
 })

--- a/test/tests/ports/transaction/checkGasPrice.spec.ts
+++ b/test/tests/ports/transaction/checkGasPrice.spec.ts
@@ -115,42 +115,14 @@ describe('when checking the gas price for a txn', () => {
           ).rejects.toThrow()
         })
 
-        describe('and the FF resolves the provider to gelato', () => {
-          beforeEach(() => {
-            resolveProviderMock.mockResolvedValue({
-              name: 'gelato',
-              provider: {},
-            })
-          })
+        it('should increment the high gas price metric', async () => {
+          await expect(
+            checkGasPrice(components, transactionData)
+          ).rejects.toThrow()
 
-          it('should increment the high gas price metric for gelato', async () => {
-            await expect(
-              checkGasPrice(components, transactionData)
-            ).rejects.toThrow()
-
-            expect(components.metrics.increment).toHaveBeenCalledWith(
-              'dcl_error_high_gas_price_gelato'
-            )
-          })
-        })
-
-        describe('and the FF resolves the provider to openzeppelin', () => {
-          beforeEach(() => {
-            resolveProviderMock.mockResolvedValue({
-              name: 'openzeppelin',
-              provider: {},
-            })
-          })
-
-          it('should increment the high gas price metric for openzeppelin', async () => {
-            await expect(
-              checkGasPrice(components, transactionData)
-            ).rejects.toThrow()
-
-            expect(components.metrics.increment).toHaveBeenCalledWith(
-              'dcl_error_high_gas_price_openzeppelin'
-            )
-          })
+          expect(components.metrics.increment).toHaveBeenCalledWith(
+            'dcl_error_high_gas_price'
+          )
         })
       })
 

--- a/test/tests/ports/transaction/checkGasPrice.spec.ts
+++ b/test/tests/ports/transaction/checkGasPrice.spec.ts
@@ -6,18 +6,17 @@ import { IFeaturesComponent } from '@well-known-components/features-component/di
 import { metricDeclarations } from '../../../../src/metrics'
 import { IContractsComponent } from '../../../../src/ports/contracts/types'
 import { checkGasPrice } from '../../../../src/ports/transaction/validation/checkGasPrice'
-import {
-  IMetaTransactionProviderComponent,
-  TransactionData,
-} from '../../../../src/types/transactions/transactions'
+import { IRelayRouterComponent } from '../../../../src/ports/relay-router/types'
+import { TransactionData } from '../../../../src/types/transactions/transactions'
 import TransactionDataMock from '../../../mocks/transactionData'
 
 let transactionData: TransactionData
 let config: IConfigComponent
 let contracts: IContractsComponent
 let features: IFeaturesComponent
-let relayer: IMetaTransactionProviderComponent
+let relayer: IRelayRouterComponent
 let relayerGetNetworkGasPriceMock: jest.Mock
+let resolveProviderMock: jest.Mock
 let getIsFeatureEnabledMock: jest.Mock
 let getFeatureVariantMock: jest.Mock
 let isCollectionAddressMock: jest.Mock
@@ -25,7 +24,7 @@ let components: {
   config: IConfigComponent
   contracts: IContractsComponent
   features: IFeaturesComponent
-  relayer: IMetaTransactionProviderComponent
+  relayer: IRelayRouterComponent
   metrics: IMetricsComponent<keyof typeof metricDeclarations>
 }
 
@@ -34,6 +33,9 @@ beforeEach(() => {
   getIsFeatureEnabledMock = jest.fn()
   getFeatureVariantMock = jest.fn()
   relayerGetNetworkGasPriceMock = jest.fn()
+  resolveProviderMock = jest
+    .fn()
+    .mockResolvedValue({ name: 'gelato', provider: {} })
   config = {
     requireString: async () => 'Sepolia',
     requireNumber: jest.fn(),
@@ -55,6 +57,7 @@ beforeEach(() => {
   relayer = {
     sendMetaTransaction: jest.fn(),
     getNetworkGasPrice: relayerGetNetworkGasPriceMock,
+    resolveProvider: resolveProviderMock,
   }
 
   components = {
@@ -91,9 +94,7 @@ describe('when checking the gas price for a txn', () => {
 
       describe('and the current network gas price is lower than max gas price allowed', () => {
         beforeEach(() => {
-          relayerGetNetworkGasPriceMock.mockResolvedValueOnce(
-            1000000000n
-          )
+          relayerGetNetworkGasPriceMock.mockResolvedValueOnce(1000000000n)
         })
 
         it('should not throw an error', async () => {
@@ -105,9 +106,7 @@ describe('when checking the gas price for a txn', () => {
 
       describe('and the current network gas price is greater than max gas price allowed', () => {
         beforeEach(() => {
-          relayerGetNetworkGasPriceMock.mockResolvedValueOnce(
-            2100000000n
-          )
+          relayerGetNetworkGasPriceMock.mockResolvedValue(2100000000n)
         })
 
         it('should throw an error', async () => {
@@ -116,14 +115,42 @@ describe('when checking the gas price for a txn', () => {
           ).rejects.toThrow()
         })
 
-        it('should increment the high gas price metric', async () => {
-          await expect(
-            checkGasPrice(components, transactionData)
-          ).rejects.toThrow()
+        describe('and the FF resolves the provider to gelato', () => {
+          beforeEach(() => {
+            resolveProviderMock.mockResolvedValue({
+              name: 'gelato',
+              provider: {},
+            })
+          })
 
-          expect(components.metrics.increment).toHaveBeenCalledWith(
-            'dcl_error_high_gas_price_gelato'
-          )
+          it('should increment the high gas price metric for gelato', async () => {
+            await expect(
+              checkGasPrice(components, transactionData)
+            ).rejects.toThrow()
+
+            expect(components.metrics.increment).toHaveBeenCalledWith(
+              'dcl_error_high_gas_price_gelato'
+            )
+          })
+        })
+
+        describe('and the FF resolves the provider to openzeppelin', () => {
+          beforeEach(() => {
+            resolveProviderMock.mockResolvedValue({
+              name: 'openzeppelin',
+              provider: {},
+            })
+          })
+
+          it('should increment the high gas price metric for openzeppelin', async () => {
+            await expect(
+              checkGasPrice(components, transactionData)
+            ).rejects.toThrow()
+
+            expect(components.metrics.increment).toHaveBeenCalledWith(
+              'dcl_error_high_gas_price_openzeppelin'
+            )
+          })
         })
       })
 
@@ -159,9 +186,7 @@ describe('when checking the gas price for a txn', () => {
           },
           enabled: true,
         })
-        relayerGetNetworkGasPriceMock.mockResolvedValueOnce(
-          2100000000n
-        )
+        relayerGetNetworkGasPriceMock.mockResolvedValueOnce(2100000000n)
       })
 
       describe('and the txn is an approve of the collection manager to spend mana on behalf of the user', () => {

--- a/test/tests/ports/transaction/transaction-component.spec.ts
+++ b/test/tests/ports/transaction/transaction-component.spec.ts
@@ -10,17 +10,15 @@ import { metricDeclarations } from '../../../../src/metrics'
 import { IContractsComponent } from '../../../../src/ports/contracts/types'
 import { createTransactionComponent } from '../../../../src/ports/transaction/component'
 import { ITransactionComponent } from '../../../../src/ports/transaction/types'
-import {
-  IMetaTransactionProviderComponent,
-  TransactionData,
-} from '../../../../src/types/transactions/transactions'
+import { IRelayRouterComponent } from '../../../../src/ports/relay-router/types'
+import { TransactionData } from '../../../../src/types/transactions/transactions'
 
 let transaction: ITransactionComponent
 let fetcher: IFetchComponent
 let metrics: IMetricsComponent<keyof typeof metricDeclarations>
 let config: IConfigComponent
 let logs: ILoggerComponent
-let relayer: IMetaTransactionProviderComponent
+let relayer: IRelayRouterComponent
 let transactionData: TransactionData
 let contracts: IContractsComponent
 let pg: IPgComponent
@@ -40,6 +38,9 @@ beforeEach(() => {
   relayer = {
     sendMetaTransaction: mockedRelayerSendMetaTransaction,
     getNetworkGasPrice: jest.fn(),
+    resolveProvider: jest
+      .fn()
+      .mockResolvedValue({ name: 'gelato', provider: {} }),
   }
   contracts = {} as IContractsComponent
   pg = {


### PR DESCRIPTION
## Summary
- **Add OZ metrics by adding four counters**:
     - `dcl_error_cancelled_transactions_openzeppelin`
     - `dcl_error_reverted_transactions_openzeppelin`
     - `dcl_error_no_balance_transactions_openzeppelin`
     - `dcl_error_high_gas_price_openzeppelin`

- The poll-failure branch and send-time error paths now dispatch by `status` + `status_reason` via keyword inspection, with `service_errors` as the unmapped fallback.

- **Fixes a latent bug** in `checkGasPrice`: it always emitted `dcl_error_high_gas_price_gelato` regardless of which provider the FF resolved to. Promotes the relay-router's internal `resolveProvider()` closure to a public method so `checkGasPrice` can label the metric correctly per-request.
- Tightens `IRelayRouterComponent` with a `ProviderName = 'gelato' | 'openzeppelin'` literal union; `validateMetricsDeclaration` is the compile-time safety net for adding new providers.
