### PR TITLE
docs: add AGENTS.md, CLAUDE.md, and Claude Code project config

### DIFF
--- a/.agents/skills/dcl-backend-standards/SKILL.md
+++ b/.agents/skills/dcl-backend-standards/SKILL.md
@@ -1,0 +1,303 @@
+---
+name: dcl-backend-standards
+description: Decentraland backend coding standards. ALWAYS follow when writing, modifying, or reviewing any *.ts file in a backend service. Covers type safety, error handling, security, HTTP conventions, logging, environment config, database access, async discipline, and outbound call patterns.
+license: MIT
+---
+
+# Backend Coding Standards
+
+## Scope
+
+Apply to: all `*.ts` files in Decentraland backend services (test files excluded — see dcl-testing).
+
+## Core Rules
+
+### 1. Type Safety (MUST)
+
+Avoid `as` type assertions. Use `Pick<>`, `Partial<>`, type guards, or proper type narrowing instead.
+
+```typescript
+// BAD
+const user = { id, name } as UserAttributes
+
+// GOOD
+const user: Pick<UserAttributes, 'id' | 'name'> = { id, name }
+```
+
+Never use non-null assertions (`!`) without a preceding guard that throws a domain error.
+
+```typescript
+// BAD
+const roomId = session.room_id!
+
+// GOOD
+if (!session.room_id) {
+  throw new MissingRoomError('Session has no room_id')
+}
+const roomId = session.room_id
+```
+
+Prefer explicit return types on exported functions.
+
+### 2. Error Handling (MUST)
+
+Always guard `JSON.parse` on external or stored data with try/catch.
+
+```typescript
+// BAD
+const metadata = JSON.parse(record?.metadata || '{}')
+
+// GOOD
+let metadata: RecordMetadata = {}
+try {
+  metadata = JSON.parse(record?.metadata || '{}')
+} catch {
+  logger.warn('Failed to parse record metadata', { recordId })
+}
+```
+
+When adding a guard or pattern to one code path, apply it consistently to all similar paths. If `removeItem` has a null guard, `addItem` must too.
+
+Use typed domain error classes, not generic `Error`.
+
+Wrap HTTP handler bodies in a single try-catch. Business logic and validation throw typed domain errors; the catch block maps each error type to the correct HTTP status and response body in one place. Avoid multiple early returns that each manually construct status + error body.
+
+```typescript
+// BAD — duplicated response shaping, multiple return points
+async function handleUpdateItem(ctx: Context) {
+  const item = await db.getItem(ctx.params.id)
+  if (!item) {
+    return { status: 404, body: { ok: false, message: 'Item not found' } }
+  }
+
+  if (item.owner !== ctx.auth.address) {
+    return { status: 403, body: { ok: false, message: 'Not the owner' } }
+  }
+
+  const updated = await db.updateItem(ctx.params.id, ctx.body)
+  return { status: 200, body: { ok: true, data: updated } }
+}
+
+// GOOD — single try-catch, typed errors, one response-shaping point
+async function handleUpdateItem(ctx: Context) {
+  try {
+    const item = await getItemOrThrow(ctx.params.id)       // throws NotFoundError
+    assertOwnership(item, ctx.auth.address)                 // throws ForbiddenError
+    const updated = await db.updateItem(ctx.params.id, ctx.body)
+    return { status: 200, body: { ok: true, data: updated } }
+  } catch (error) {
+    return mapErrorToResponse(error)
+  }
+}
+```
+
+### 3. Security (MUST)
+
+Validate the full request schema at the service boundary. Do not rely on individual field checks scattered through business logic.
+
+```typescript
+// BAD — validation scattered, easy to miss fields
+async function handleCreateItem(ctx: Context) {
+  if (!ctx.body.name) throw new ValidationError('name required')
+  // description is never validated...
+}
+
+// GOOD — validate entire schema at the edge, using whatever validation library the project uses
+const CreateItemSchema = {
+  type: 'object',
+  properties: {
+    name: { type: 'string', minLength: 1, maxLength: 200 },
+    tags: { type: 'array', items: { type: 'string', maxLength: 50 }, maxItems: 20 },
+  },
+  required: ['name'],
+  additionalProperties: false,
+}
+```
+
+Always set `maxLength` on string fields and `maxItems` on array fields in request schemas to prevent payload abuse.
+
+Be explicit about type coercion at boundaries. Query parameters and environment variables are always strings — parse and validate them intentionally.
+
+```typescript
+// BAD — parseInt silently succeeds on partial input
+const limit = parseInt(ctx.query.limit) // parseInt("123abc") → 123
+
+// GOOD — strict numeric parsing with validation
+const limit = Number(ctx.query.limit)
+if (!Number.isFinite(limit) || limit < 1 || limit > 100) {
+  throw new ValidationError('limit must be a number between 1 and 100')
+}
+```
+
+Prefer allowlists over denylists when validating input values.
+
+All HTTP endpoints must have auth middleware (`auth`, `tokenAuthMiddleware`, or equivalent) unless the reason for omitting it is explicitly documented in a code comment.
+
+Follow the principle of least privilege for permissions. Default to the most restrictive option.
+
+```typescript
+// BAD — grants unnecessary permissions
+canUpdateMetadata: true  // default, but viewers don't need this
+
+// GOOD — explicitly restrictive
+canUpdateMetadata: false
+```
+
+### 4. HTTP Conventions (MUST)
+
+Use correct HTTP status codes:
+
+| Code | Meaning         | When to use                                      |
+|------|-----------------|--------------------------------------------------|
+| 401  | Unauthenticated | Identity unknown — who are you?                  |
+| 403  | Unauthorized    | Identity known but access denied — you can't do this |
+| 404  | Not Found       | Resource does not exist                          |
+| 409  | Conflict        | Action conflicts with current state              |
+
+```typescript
+// BAD — user is authenticated but not an admin
+throw new HttpError(401, 'Not authorized')
+
+// GOOD
+throw new HttpError(403, 'Admin access required')
+```
+
+### 5. Logging & Observability (SHOULD)
+
+Use structured logging via the `logger` component. Never use `console.log`.
+
+```typescript
+// BAD
+console.log('Failed to process request')
+
+// GOOD
+logger.warn('Failed to process request', { requestId, userId, reason })
+```
+
+Always include context objects in log calls with relevant IDs and operation details.
+
+Use appropriate log levels: `error` for failures requiring attention, `warn` for recoverable issues, `info` for significant operations, `debug` for troubleshooting detail.
+
+### 6. Environment & Config (SHOULD)
+
+Read environment variables through the `config` component. Never access `process.env` directly.
+
+```typescript
+// BAD
+const port = process.env.PORT || '3000'
+
+// GOOD
+const port = await config.getString('PORT', '3000')
+```
+
+Always provide sensible default values for optional configuration.
+
+Do not hardcode values that should be configurable (URLs, ports, intervals, thresholds).
+
+### 7. Database Access (MUST)
+
+Always use parameterized queries. Never interpolate variables into SQL strings.
+
+```typescript
+// BAD — SQL injection risk
+const result = await db.query(`SELECT * FROM items WHERE id = '${id}'`)
+
+// GOOD — parameterized
+const result = await db.query('SELECT * FROM items WHERE id = $1', [id])
+```
+
+Wrap multi-step mutations in a transaction. If any step fails, the entire operation rolls back.
+
+```typescript
+// BAD — partial failure leaves inconsistent state
+await db.query('INSERT INTO orders ...', [orderData])
+await db.query('UPDATE inventory SET quantity = quantity - $1 ...', [qty])
+
+// GOOD — atomic operation
+await db.withTransaction(async (client) => {
+  await client.query('INSERT INTO orders ...', [orderData])
+  await client.query('UPDATE inventory SET quantity = quantity - $1 ...', [qty])
+})
+```
+
+Use the WKC database component for connection pooling — never create per-request connections.
+
+Prevent N+1 queries: batch-load related data with `WHERE id = ANY($1)` or joins instead of looping queries.
+
+Set `statement_timeout` on long-running queries to prevent runaway operations from exhausting connections.
+
+### 8. Async Discipline (MUST)
+
+Never call an async function without `await` unless it is intentionally fire-and-forget — in that case, attach `.catch()` and add a comment explaining why.
+
+```typescript
+// BAD — floating promise, errors vanish silently
+sendNotification(userId, message)
+
+// GOOD — awaited
+await sendNotification(userId, message)
+
+// GOOD — intentional fire-and-forget with error handling
+// Fire-and-forget: notification failure must not block the response
+sendNotification(userId, message).catch((err) =>
+  logger.warn('Failed to send notification', { userId, error: err.message })
+)
+```
+
+Never use `forEach` with async callbacks — iterations run concurrently with no await and no error propagation.
+
+```typescript
+// BAD — silently swallowed errors, no backpressure
+items.forEach(async (item) => {
+  await processItem(item)
+})
+
+// GOOD — concurrent with error propagation
+await Promise.all(items.map((item) => processItem(item)))
+
+// GOOD — sequential when order or rate matters
+for (const item of items) {
+  await processItem(item)
+}
+```
+
+Use `Promise.all` when all results are required (fail-fast on first rejection). Use `Promise.allSettled` when partial success is acceptable and you need to inspect each outcome.
+
+Always clean up resources in `finally` blocks in async flows (open handles, temp files, locks).
+
+### 9. Outbound Calls (SHOULD)
+
+Set an explicit timeout on every outbound HTTP call. Never rely on default TCP timeouts.
+
+```typescript
+// BAD — no timeout, can hang for minutes
+const response = await fetch('https://external-api.example.com/data')
+
+// GOOD — explicit timeout
+const response = await fetch('https://external-api.example.com/data', {
+  signal: AbortSignal.timeout(5000),
+})
+```
+
+Distinguish retryable errors from fatal ones. Retry `503`, `429`, and network errors with exponential backoff and jitter. Do not retry `400`, `401`, `403`, or `404`.
+
+```typescript
+// BAD — retries everything blindly
+for (let i = 0; i < 3; i++) {
+  try { return await callExternalService(); } catch { /* retry */ }
+}
+
+// GOOD — only retry transient failures
+const isRetryable = (status: number) => [503, 429, 502].includes(status)
+```
+
+## Related Skills (optional companions)
+
+These skills complement `dcl-backend-standards` but are not required:
+
+- Architecture & component design (WKC structure, lifecycle, DI): `dcl-wkc-components`
+- Test patterns and mocking: `dcl-testing`
+
+---
+
+For extended examples, common mistakes, and AI validation checklist, see [references/REFERENCE.md](references/REFERENCE.md)

--- a/.agents/skills/dcl-backend-standards/references/REFERENCE.md
+++ b/.agents/skills/dcl-backend-standards/references/REFERENCE.md
@@ -1,0 +1,501 @@
+# Backend Coding Standards - Detailed Reference
+
+## Examples
+
+### Type Safety
+
+```typescript
+// BAD — type assertion hides a missing required field
+const response = { status: 'ok' } as ApiResponse
+
+// GOOD — compiler enforces the correct shape
+const response: Pick<ApiResponse, 'status'> = { status: 'ok' }
+```
+
+```typescript
+// BAD — non-null assertion without guard
+const userId = request.auth.userId!
+await database.query('DELETE FROM sessions WHERE user_id = $1', [userId])
+
+// GOOD — guard throws a domain error, then access is safe
+if (!request.auth.userId) {
+  throw new UnauthenticatedError('Missing user ID in auth context')
+}
+const userId = request.auth.userId
+await database.query('DELETE FROM sessions WHERE user_id = $1', [userId])
+```
+
+```typescript
+// BAD — as bypasses narrowing on union types
+function getDisplayName(entity: User | Organization) {
+  return (entity as User).firstName
+}
+
+// GOOD — type guard with proper narrowing
+function isUser(entity: User | Organization): entity is User {
+  return 'firstName' in entity
+}
+
+function getDisplayName(entity: User | Organization): string {
+  if (isUser(entity)) {
+    return entity.firstName
+  }
+  return entity.orgName
+}
+```
+
+### Error Handling
+
+```typescript
+// BAD — JSON.parse on data from external source without guard
+async function getSettings(key: string): Promise<Settings> {
+  const raw = await redis.get(key)
+  return JSON.parse(raw || '{}')
+}
+
+// GOOD — guarded with try/catch, logged, safe default
+async function getSettings(key: string): Promise<Settings> {
+  const raw = await redis.get(key)
+  let settings: Settings = {}
+  try {
+    settings = JSON.parse(raw || '{}')
+  } catch {
+    logger.warn('Failed to parse settings from cache', { key })
+  }
+  return settings
+}
+```
+
+```typescript
+// BAD — guard on removeItem but not addItem
+function removeItem(list: string[] | null, item: string): string[] {
+  if (!list) return []
+  return list.filter(i => i !== item)
+}
+
+function addItem(list: string[], item: string): string[] {
+  return [...list, item] // crashes if list is null
+}
+
+// GOOD — consistent null guard on both paths
+function removeItem(list: string[] | null, item: string): string[] {
+  if (!list) return []
+  return list.filter(i => i !== item)
+}
+
+function addItem(list: string[] | null, item: string): string[] {
+  if (!list) return [item]
+  return [...list, item]
+}
+```
+
+### Handler Error Flow
+
+```typescript
+// BAD — each error condition builds its own response, logic is scattered
+async function handleCreateProject(ctx: Context) {
+  const { name, description } = ctx.body
+
+  if (!name || name.length > 128) {
+    return { status: 400, body: { ok: false, message: 'Invalid project name' } }
+  }
+
+  const org = await db.getOrganization(ctx.body.orgId)
+  if (!org) {
+    return { status: 404, body: { ok: false, message: 'Organization not found' } }
+  }
+
+  if (!org.members.includes(ctx.auth.address)) {
+    return { status: 403, body: { ok: false, message: 'Not a member of this organization' } }
+  }
+
+  const existing = await db.getProjectByName(org.id, name)
+  if (existing) {
+    return { status: 409, body: { ok: false, message: 'Project name already taken' } }
+  }
+
+  const project = await db.createProject({ name, description, orgId: org.id })
+  return { status: 201, body: { ok: true, data: project } }
+}
+
+// GOOD — validation and business logic throw typed errors, single catch maps them
+async function handleCreateProject(ctx: Context) {
+  try {
+    const { name, description } = validateProjectInput(ctx.body)  // throws ValidationError
+    const org = await getOrganizationOrThrow(ctx.body.orgId)      // throws NotFoundError
+    assertMembership(org, ctx.auth.address)                        // throws ForbiddenError
+    await assertProjectNameAvailable(org.id, name)                 // throws ConflictError
+
+    const project = await db.createProject({ name, description, orgId: org.id })
+    return { status: 201, body: { ok: true, data: project } }
+  } catch (error) {
+    return mapErrorToResponse(error)
+  }
+}
+
+// Shared error-to-response mapper (used by all handlers)
+function mapErrorToResponse(error: unknown) {
+  if (error instanceof ValidationError) {
+    return { status: 400, body: { ok: false, message: error.message } }
+  }
+  if (error instanceof NotFoundError) {
+    return { status: 404, body: { ok: false, message: error.message } }
+  }
+  if (error instanceof ForbiddenError) {
+    return { status: 403, body: { ok: false, message: error.message } }
+  }
+  if (error instanceof ConflictError) {
+    return { status: 409, body: { ok: false, message: error.message } }
+  }
+  logger.error('Unhandled error in request handler', { error: String(error) })
+  return { status: 500, body: { ok: false, message: 'Internal server error' } }
+}
+```
+
+### Security
+
+```typescript
+// BAD — no length constraints on string fields
+const schema = {
+  type: 'object',
+  properties: {
+    name: { type: 'string' },
+    description: { type: 'string' },
+    identity: { type: 'string' }
+  }
+}
+
+// GOOD — all string fields have maxLength
+const schema = {
+  type: 'object',
+  properties: {
+    name: { type: 'string', maxLength: 128 },
+    description: { type: 'string', maxLength: 1024 },
+    identity: { type: 'string', maxLength: 256 }
+  }
+}
+```
+
+```typescript
+// BAD — no array bounds, attacker can send 1M tags
+const schema = {
+  type: 'object',
+  properties: {
+    tags: { type: 'array', items: { type: 'string' } }
+  }
+}
+
+// GOOD — bounded arrays with bounded items
+const schema = {
+  type: 'object',
+  properties: {
+    tags: { type: 'array', items: { type: 'string', maxLength: 50 }, maxItems: 20 }
+  }
+}
+```
+
+```typescript
+// BAD — trusting query param as number without validation
+const page = parseInt(ctx.query.page)       // parseInt("12abc") → 12
+const limit = Number(ctx.query.limit)       // Number("") → 0
+
+// GOOD — explicit parsing and range validation
+const page = Number(ctx.query.page)
+if (!Number.isInteger(page) || page < 1) {
+  throw new ValidationError('page must be a positive integer')
+}
+const limit = Number(ctx.query.limit)
+if (!Number.isInteger(limit) || limit < 1 || limit > 100) {
+  throw new ValidationError('limit must be between 1 and 100')
+}
+```
+
+```typescript
+// BAD — endpoint with no auth and no explanation
+router.post('/items', handleCreateItem)
+
+// GOOD — auth middleware present
+router.post('/items', auth, handleCreateItem)
+
+// GOOD — public endpoint with documented reason
+// Public: items listing is available without authentication for catalog display
+router.get('/items', handleListItems)
+```
+
+### HTTP Conventions
+
+```typescript
+// BAD — returns 401 when the user is authenticated but lacks admin role
+async function handleDeleteUser(ctx: Context): Promise<void> {
+  const caller = ctx.auth.address
+  if (!isAdmin(caller)) {
+    throw new HttpError(401, 'Not authorized') // wrong: user IS authenticated
+  }
+  await deleteUser(ctx.params.id)
+}
+
+// GOOD — 403 for known identity without permission
+async function handleDeleteUser(ctx: Context): Promise<void> {
+  const caller = ctx.auth.address
+  if (!isAdmin(caller)) {
+    throw new HttpError(403, 'Admin access required')
+  }
+  await deleteUser(ctx.params.id)
+}
+```
+
+### Logging & Observability
+
+```typescript
+// BAD — unstructured logging with no context
+console.log('Error processing webhook')
+console.log('User created successfully')
+
+// GOOD — structured logging with context and appropriate levels
+logger.error('Failed to process webhook', { webhookId, error: err.message })
+logger.info('User created', { userId, email })
+```
+
+```typescript
+// BAD — logging sensitive data
+logger.info('User login', { email, password, token })
+
+// GOOD — only log identifiers and non-sensitive context
+logger.info('User login', { userId, email })
+```
+
+### Environment & Config
+
+```typescript
+// BAD — direct process.env access scattered across files
+const dbHost = process.env.DB_HOST || 'localhost'
+const dbPort = parseInt(process.env.DB_PORT || '5432')
+const apiUrl = 'https://api.example.com/v1' // hardcoded
+
+// GOOD — config component with defaults
+const dbHost = await config.getString('DB_HOST', 'localhost')
+const dbPort = await config.getNumber('DB_PORT', 5432)
+const apiUrl = await config.requireString('API_URL') // no default — must be set
+```
+
+### Database Access
+
+```typescript
+// BAD — string interpolation in SQL
+async function getItem(id: string) {
+  return db.query(`SELECT * FROM items WHERE id = '${id}'`)
+}
+
+// GOOD — parameterized query
+async function getItem(id: string) {
+  return db.query('SELECT * FROM items WHERE id = $1', [id])
+}
+```
+
+```typescript
+// BAD — N+1: one query per order to fetch items
+async function getOrdersWithItems(orderIds: string[]) {
+  const orders = await db.query('SELECT * FROM orders WHERE id = ANY($1)', [orderIds])
+  for (const order of orders.rows) {
+    order.items = await db.query('SELECT * FROM items WHERE order_id = $1', [order.id])
+  }
+  return orders.rows
+}
+
+// GOOD — batch load with a single query
+async function getOrdersWithItems(orderIds: string[]) {
+  const orders = await db.query('SELECT * FROM orders WHERE id = ANY($1)', [orderIds])
+  const items = await db.query('SELECT * FROM items WHERE order_id = ANY($1)', [orderIds])
+  const itemsByOrder = new Map<string, Item[]>()
+  for (const item of items.rows) {
+    const list = itemsByOrder.get(item.order_id) || []
+    list.push(item)
+    itemsByOrder.set(item.order_id, list)
+  }
+  return orders.rows.map((order) => ({ ...order, items: itemsByOrder.get(order.id) || [] }))
+}
+```
+
+```typescript
+// BAD — no transaction, partial failure leaves orphan record
+async function createProjectWithOwner(projectData: ProjectInput, userId: string) {
+  const project = await db.query('INSERT INTO projects ... RETURNING id', [projectData])
+  await db.query('INSERT INTO project_members (project_id, user_id, role) VALUES ($1, $2, $3)',
+    [project.rows[0].id, userId, 'owner'])
+}
+
+// GOOD — transactional, atomic operation
+async function createProjectWithOwner(projectData: ProjectInput, userId: string) {
+  await db.withTransaction(async (client) => {
+    const project = await client.query('INSERT INTO projects ... RETURNING id', [projectData])
+    await client.query('INSERT INTO project_members (project_id, user_id, role) VALUES ($1, $2, $3)',
+      [project.rows[0].id, userId, 'owner'])
+  })
+}
+```
+
+### Async Discipline
+
+```typescript
+// BAD — floating promise: if analytics throws, error is swallowed
+function handleUserAction(userId: string, action: string) {
+  trackAnalytics(userId, action) // async but not awaited, no catch
+  return { ok: true }
+}
+
+// GOOD — awaited
+async function handleUserAction(userId: string, action: string) {
+  await trackAnalytics(userId, action)
+  return { ok: true }
+}
+
+// GOOD — intentional fire-and-forget with error handling and comment
+function handleUserAction(userId: string, action: string) {
+  // Fire-and-forget: analytics failure must not block the user response
+  trackAnalytics(userId, action).catch((err) =>
+    logger.warn('Analytics tracking failed', { userId, action, error: err.message })
+  )
+  return { ok: true }
+}
+```
+
+```typescript
+// BAD — forEach with async: iterations run uncontrolled, errors vanish
+async function notifyUsers(userIds: string[], message: string) {
+  userIds.forEach(async (userId) => {
+    await sendNotification(userId, message)
+  })
+  // function returns before any notification is sent
+}
+
+// GOOD — concurrent with error propagation
+async function notifyUsers(userIds: string[], message: string) {
+  await Promise.all(userIds.map((userId) => sendNotification(userId, message)))
+}
+
+// GOOD — sequential when order or rate limiting matters
+async function notifyUsers(userIds: string[], message: string) {
+  for (const userId of userIds) {
+    await sendNotification(userId, message)
+  }
+}
+```
+
+```typescript
+// BAD — Promise.all when partial success is acceptable (one failure kills all)
+async function syncAllProviders(providers: Provider[]) {
+  const results = await Promise.all(providers.map((p) => p.sync()))
+  return results
+}
+
+// GOOD — Promise.allSettled to handle partial success
+async function syncAllProviders(providers: Provider[]) {
+  const results = await Promise.allSettled(providers.map((p) => p.sync()))
+  const failures = results.filter((r) => r.status === 'rejected')
+  if (failures.length > 0) {
+    logger.warn('Some providers failed to sync', { failedCount: failures.length })
+  }
+  return results
+    .filter((r): r is PromiseFulfilledResult<SyncResult> => r.status === 'fulfilled')
+    .map((r) => r.value)
+}
+```
+
+### Outbound Calls
+
+```typescript
+// BAD — no timeout, request can hang indefinitely
+async function fetchExternalProfile(userId: string) {
+  const response = await fetch(`https://api.external.com/users/${userId}`)
+  return response.json()
+}
+
+// GOOD — explicit timeout
+async function fetchExternalProfile(userId: string) {
+  const response = await fetch(`https://api.external.com/users/${userId}`, {
+    signal: AbortSignal.timeout(5000),
+  })
+  return response.json()
+}
+```
+
+```typescript
+// BAD — retries all errors including client errors
+async function callWithRetry(fn: () => Promise<Response>) {
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try {
+      return await fn()
+    } catch {
+      if (attempt === 2) throw new Error('Max retries exceeded')
+    }
+  }
+}
+
+// GOOD — only retry transient failures, with backoff and jitter
+const RETRYABLE_STATUS = new Set([502, 503, 429])
+
+async function callWithRetry(fn: () => Promise<Response>, maxAttempts = 3) {
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    const response = await fn()
+    if (response.ok || !RETRYABLE_STATUS.has(response.status)) {
+      return response
+    }
+    if (attempt < maxAttempts - 1) {
+      const backoff = Math.min(1000 * 2 ** attempt, 10000)
+      const jitter = Math.random() * backoff * 0.1
+      await new Promise((resolve) => setTimeout(resolve, backoff + jitter))
+    }
+  }
+  throw new Error('Max retries exceeded for transient failure')
+}
+```
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---|---|
+| `as SomeType` to silence the compiler | Use `Pick<>`, `Partial<>`, or a type guard |
+| `obj.prop!` without preceding check | Add a null/undefined guard that throws a domain error |
+| Unguarded `JSON.parse` on external data | Wrap in try/catch, log the failure, use a safe default |
+| String fields without `maxLength` in schema validation | Add length constraints to all string fields |
+| HTTP endpoint missing auth middleware | Add auth middleware or document why it's intentionally public |
+| 401 for "not authorized" | Use 403 — 401 means identity is unknown (unauthenticated) |
+| `console.log` in production code | Use the structured `logger` component with context |
+| `process.env.VAR` accessed directly | Use `config.getString('VAR', defaultValue)` |
+| Guard on one path but not its sibling | Apply the same guard pattern to all similar code paths |
+| Multiple early returns in handler, each building status + error body | Wrap handler in try-catch; throw typed domain errors; map them in a single catch block |
+| Hardcoded URLs, ports, or timeouts | Move to config with sensible defaults |
+| Logging sensitive data (passwords, tokens) | Only log identifiers and non-sensitive context |
+| String interpolation in SQL (`WHERE id = '${id}'`) | Use parameterized queries (`WHERE id = $1`, `[id]`) |
+| Query inside a loop (N+1) | Batch-load with `WHERE id = ANY($1)` or use joins |
+| Multi-step DB mutation without transaction | Wrap in `db.withTransaction()` |
+| Async function called without `await` or `.catch()` | Await it, or add `.catch()` with a comment if fire-and-forget |
+| `forEach` with async callback | Use `Promise.all(arr.map(...))` or `for...of` |
+| `Promise.all` when partial success is acceptable | Use `Promise.allSettled` and inspect each outcome |
+| Outbound HTTP call without timeout | Add `signal: AbortSignal.timeout(ms)` |
+| Retrying 400/401/404 errors | Only retry transient failures (503, 429, network errors) |
+| Array fields in schema without `maxItems` | Add `maxItems` to all array fields |
+| Trusting `parseInt`/`Number` without range validation | Validate parsed numbers are finite and within expected bounds |
+
+## AI Validation
+
+When AI creates or updates backend code, it MUST verify:
+
+1. No `as` type assertions or unguarded `!` operators
+2. All `JSON.parse` calls on external data are wrapped in try/catch
+3. All string fields in schemas have `maxLength` and all array fields have `maxItems` constraints
+4. All HTTP endpoints have auth middleware (or a documented reason for omission)
+5. HTTP status codes are semantically correct (especially 401 vs 403)
+6. All logging uses structured `logger`, never `console.log`
+7. All config access goes through the `config` component, never `process.env`
+8. Guards are applied consistently across similar code paths
+9. HTTP handlers use a single try-catch wrapper — no scattered early returns with manual status/body construction
+10. No sensitive data (passwords, tokens, secrets) in log output
+11. All SQL queries use parameterized placeholders — no string interpolation
+12. Multi-step DB mutations are wrapped in a transaction
+13. No N+1 query patterns — related data is batch-loaded
+14. No floating promises — every async call is `await`ed or has `.catch()` with a comment
+15. No `forEach` with async callbacks — use `Promise.all(map(...))` or `for...of`
+16. All outbound HTTP calls have an explicit timeout (`AbortSignal.timeout()`)
+17. Request schema is validated at the service boundary, not scattered through business logic
+18. Query parameter and env var parsing includes explicit type validation

--- a/.agents/skills/dcl-testing/SKILL.md
+++ b/.agents/skills/dcl-testing/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: dcl-testing
+description: Decentraland testing standards. ALWAYS follow when writing, modifying, or reviewing files matching *.spec.ts, *.test.ts, *.spec.tsx, *.test.tsx. Enforces Jest + TypeScript patterns including describe/it semantic naming ("when"/"and"/"should"), mock scoping with beforeEach/afterEach, jest.fn(), mockReturnValueOnce, React Testing Library (getByRole, getByLabelText, userEvent), redux-saga-test-plan, supertest, and Cypress E2E. Prevents common mistakes like global mocks, variables inside it(), and flat test structure.
+license: MIT
+---
+
+# Testing Standards
+
+## Scope
+
+Apply to all test files: `*.test.ts`, `*.spec.ts`, `*.test.tsx`, `*.spec.tsx`
+
+## Rules
+
+### MUST (required)
+
+- Use Jest and TypeScript for all tests.
+- Organize tests with `describe` (context: "when", "and") and `it` (behavior: "should ...").
+- Each context variant must have its own describe block with "when" or "and"
+- Use "when" for main contexts and "and" for nested contexts
+- Do NOT use "when" in it() descriptions - the context is already defined in the describe
+- it() descriptions must be specific and descriptive about the expected behavior
+- Prefer specific outcomes over generic ones (e.g., "should respond with a 500 and the error" vs "should return 500 status")
+- Use `beforeEach` for setup, never mix with `beforeAll`.
+- All test variables, input data, and mocks must be declared and assigned in beforeEach
+- Do NOT define input variables inside it() blocks
+- Each describe context should have its own beforeEach for its specific setup
+- Mocks and test data must be scoped to the specific describe context where they are needed
+- Do NOT create mocks in global beforeEach that are only used in specific describe contexts
+- Each describe context should set up only the test data and mock overrides specific to that context in its own beforeEach
+- Create mock components (via factory functions) and the system under test once in the top-level beforeEach. Do NOT recreate them in nested describe blocks.
+- When a nested context needs different mock behavior, override the specific method on the existing mock (e.g. `mockComponent.method.mockResolvedValue(newValue)`) instead of recreating the entire mock component.
+- Never recreate the system under test in nested describe blocks just to change a mock's return value. For class-based or DI-based code, the instance already holds references to its mocks — overriding the mock method is sufficient. For React components, override mock module/hook return values before rendering.
+- When mock factories return `jest.Mocked<T>`, leverage the typing to call `.mockResolvedValue()`, `.mockReturnValue()`, etc. directly on individual methods.
+- Use `afterEach` to clean up mocks, test data, and side effects to ensure test isolation.
+- Use `let` for mutable, `const` for immutable variables. Type variables explicitly.
+- Have one assertion per `it` unless justified for performance or testing multiple aspects of the same behavior.
+- Test behavior, not implementation. Focus on what the code does, not how.
+- Use `jest.fn()` for mocks, prefer `mockReturnValueOnce`/`mockResolvedValueOnce`, and reset mocks in `afterEach`.
+- Keep tests independent and use clear, explicit descriptions.
+
+### SHOULD (recommended)
+
+- Use React Testing Library and accessible queries (`getByRole`, `getByLabelText`, etc.) for React components.
+- Test reducers with action creators, selectors as functions, sagas with `redux-saga-test-plan`.
+- Use `supertest` for API tests and Cypress for E2E.
+- Place test files next to the code they test, named `*.spec.ts(x)` or `*.test.ts(x)`.
+- Test accessibility and keyboard navigation.
+- Place test utilities in a `__tests__/` directory when needed.
+
+For examples, common mistakes, and AI validation checklist, see [references/REFERENCE.md](references/REFERENCE.md)

--- a/.agents/skills/dcl-testing/references/REFERENCE.md
+++ b/.agents/skills/dcl-testing/references/REFERENCE.md
@@ -1,0 +1,145 @@
+# Testing Standards - Detailed Reference
+
+## Examples
+
+### Correct Structure
+
+```typescript
+describe("when the form is submitted", () => {
+  let mockSubmit: jest.Mock;
+
+  beforeEach(() => {
+    mockSubmit = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe("and the input is valid", () => {
+    let validInput: any;
+
+    beforeEach(() => {
+      validInput = { name: "test", email: "test@test.com" };
+    });
+
+    it("should call the onSubmit callback", () => {
+      mockSubmit();
+      expect(mockSubmit).toHaveBeenCalled();
+    });
+  });
+
+  describe("and the input is invalid", () => {
+    let invalidInput: any;
+
+    beforeEach(() => {
+      invalidInput = { name: "", email: "invalid" };
+    });
+
+    it("should display a validation error", () => {
+      /* ... */
+    });
+  });
+});
+```
+
+### Scoped Mocks (Correct vs Incorrect)
+
+```typescript
+// BAD - Global mocks used in specific contexts
+describe("when testing API endpoints", () => {
+  let validAuthChain: AuthChain;
+  let invalidAuthChain: AuthChain;
+
+  beforeEach(async () => {
+    validAuthChain = createValidAuthChain();
+    invalidAuthChain = createInvalidAuthChain();
+  });
+
+  describe("and the request is valid", () => {
+    it("should respond with 200", () => {
+      // Uses validAuthChain - but it was created globally
+    });
+  });
+});
+
+// GOOD - Mocks scoped to specific contexts
+describe("when testing API endpoints", () => {
+  beforeEach(async () => {
+    port = await getPort();
+    baseUrl = `http://localhost:${port}`;
+  });
+
+  describe("and the request is valid", () => {
+    let validAuthChain: AuthChain;
+
+    beforeEach(async () => {
+      validAuthChain = createValidAuthChain();
+    });
+
+    it("should respond with 200", () => {
+      // Uses validAuthChain - created in this context
+    });
+  });
+
+  describe("and the request is invalid", () => {
+    let invalidAuthChain: AuthChain;
+
+    beforeEach(() => {
+      invalidAuthChain = createInvalidAuthChain();
+    });
+
+    it("should respond with 400", () => {
+      // Uses invalidAuthChain - created in this context
+    });
+  });
+});
+```
+
+### Mock Component Reuse (Correct vs Incorrect)
+
+```typescript
+// BAD - Recreating mock components and system under test in nested describes
+describe('when the caller is not an admin', () => {
+  beforeEach(() => {
+    mockSceneManager = createSceneManagerMockedComponent({
+      isSceneOwnerOrAdmin: jest.fn().mockResolvedValue(false)
+    })
+    // Recreating the entire system under test just to change one mock
+    systemUnderTest = createComponent({
+      sceneManager: mockSceneManager,
+      otherDep: mockOtherDep,
+      anotherDep: mockAnotherDep,
+    })
+  })
+})
+
+// GOOD - Override only the specific mock method
+describe('when the caller is not an admin', () => {
+  beforeEach(() => {
+    mockSceneManager.isSceneOwnerOrAdmin.mockResolvedValue(false)
+  })
+})
+```
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---|---|
+| `it('should fail when email is missing')` | Use `describe('when email is missing')` + `it('should return 400 status')` |
+| Variables defined inside `it()` | Move to `beforeEach` in the enclosing `describe` |
+| Global mocks for specific contexts | Scope mocks to the `describe` where they're used |
+| Flat structure without context | Use nested `describe` blocks with "when"/"and" |
+| Generic descriptions like "should work" | Be specific: "should respond with a 500 and the error" |
+| Recreating entire mock component to change one method's return value | Override the specific method: `mock.method.mockResolvedValue(newValue)` |
+| Recreating the system under test in nested describes | Create it once in top-level beforeEach; it holds references to the mocks |
+
+## AI Validation
+
+When AI creates or updates tests, it MUST:
+
+1. Validate existing tests for compliance with these rules
+2. Check mock scoping in all test files
+3. Run linter after updates
+4. Provide correct vs incorrect examples
+5. Test the rules with real test files

--- a/.agents/skills/dcl-wkc-components/SKILL.md
+++ b/.agents/skills/dcl-wkc-components/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: dcl-wkc-components
+description: Decentraland Well-Known Components (WKC) backend architecture. ALWAYS follow when writing, modifying, or reviewing component files in src/components.ts, src/adapters/, src/logic/, src/controllers/, src/types/, or any file importing from @well-known-components. Covers component interfaces, factory pattern, lifecycle, dependency injection, error handling, and documentation.
+license: MIT
+---
+
+# Well-Known Components (WKC) Standards
+
+## Scope
+
+Apply to: component files (`src/components.ts`, `test/components.ts`), type definitions (`src/types/*.ts`), adapters (`src/adapters/**/*.ts`), logic components (`src/logic/*/component.ts`), controllers (`src/controllers/handlers/**/*.ts`), and API docs (`docs/openapi.yaml`).
+
+## Core Rules
+
+### 1. Component Interface Design (MUST)
+
+All components must extend `IBaseComponent` from `@well-known-components/interfaces`. Interfaces go in `types/components.ts`.
+
+```typescript
+// BAD
+export interface IUserComponent {
+  getUser: (id: string) => User
+}
+
+// GOOD
+export interface IUserComponent extends IBaseComponent {
+  getUser: (id: string) => Promise<User>
+}
+```
+
+### 2. Factory Pattern (MUST)
+
+Use async factory functions with `create*Component` naming. Accept dependencies via `Pick<AppComponents, ...>`.
+
+```typescript
+// BAD
+export function createUserComponent(db: any, logger: any) { ... }
+
+// GOOD
+export async function createUserComponent(
+  components: Pick<AppComponents, 'database' | 'logger'>
+): Promise<IUserComponent> {
+  const { database, logger } = components
+  return {
+    async getUser(id: string): Promise<User> {
+      logger.info('Fetching user', { userId: id })
+      return await database.query('SELECT * FROM users WHERE id = $1', [id])
+    }
+  }
+}
+```
+
+### 3. Lifecycle Management (MUST)
+
+Implement `START_COMPONENT` and `STOP_COMPONENT` symbols for stateful components:
+
+```typescript
+export async function createJobComponent(
+  components: Pick<AppComponents, 'config'>
+): Promise<IJobComponent> {
+  const { config } = components
+  let intervalId: NodeJS.Timer | undefined
+
+  const start = async () => {
+    intervalId = setInterval(() => { /* job logic */ }, config.getNumber('JOB_INTERVAL', 5000))
+  }
+
+  const stop = async () => {
+    if (intervalId) { clearInterval(intervalId); intervalId = undefined }
+  }
+
+  return {
+    [START_COMPONENT]: start,
+    [STOP_COMPONENT]: stop,
+    scheduleJob: (job) => { /* implementation */ }
+  }
+}
+```
+
+### 4. Directory Organization (MUST)
+
+| Directory | Purpose |
+|---|---|
+| `src/adapters/` | External service integrations (DB, APIs, S3, SNS) |
+| `src/logic/` | Business logic components (domain-specific) |
+| `src/controllers/` | Request/response handling (HTTP, RPC, WebSocket) |
+| `src/types/` | Shared type definitions |
+
+Component file patterns:
+- Interface in `types/components.ts` or `logic/component/types.ts`
+- Implementation in `logic/component/component.ts` with `index.ts` for exports
+- Wiring in `components.ts`
+
+### 5. Dependency Injection (MUST)
+
+Use `Pick<AppComponents, 'dep1' | 'dep2'>` for explicit dependencies. Destructure at the start of factory functions. Avoid circular dependencies.
+
+### 6. Error Handling (SHOULD)
+
+Use typed error classes, implement proper logging/tracing, handle init failures gracefully.
+
+### 7. JSDoc Documentation (MUST)
+
+- Document all factory functions with description, orchestration flow, and `@param`/`@returns`
+- Document all public methods with `@param`, `@returns`, `@throws`
+- Document interface methods for IDE support
+- Document complex flows with numbered steps
+
+### 8. OpenAPI Documentation (MUST)
+
+- Create `docs/openapi.yaml` with OpenAPI 3.x.x
+- Document all HTTP endpoints with request/response schemas
+- Include error responses with proper status codes
+- Update whenever endpoints change
+
+For complete examples and detailed patterns, see [references/REFERENCE.md](references/REFERENCE.md)

--- a/.agents/skills/dcl-wkc-components/references/REFERENCE.md
+++ b/.agents/skills/dcl-wkc-components/references/REFERENCE.md
@@ -1,0 +1,296 @@
+# Well-Known Components - Detailed Reference
+
+## Complete Component Implementation Example
+
+```typescript
+// types/components.ts
+/**
+ * User management component interface
+ */
+export interface IUserComponent extends IBaseComponent {
+  /**
+   * Retrieves a user by their unique identifier
+   *
+   * @param id - The unique identifier of the user
+   * @returns Promise resolving to the user object
+   * @throws {UserNotFoundError} If the user does not exist
+   */
+  getUser: (id: string) => Promise<User>
+
+  /**
+   * Creates a new user with the provided data
+   *
+   * @param data - User creation data including email and name
+   * @returns Promise resolving to the created user object
+   * @throws {ValidationError} If user data is invalid
+   * @throws {DuplicateUserError} If a user with the same email already exists
+   */
+  createUser: (data: CreateUserData) => Promise<User>
+
+  /**
+   * Updates an existing user with new data
+   *
+   * @param id - The unique identifier of the user to update
+   * @param data - User update data containing fields to modify
+   * @returns Promise resolving to the updated user object
+   * @throws {UserNotFoundError} If the user does not exist
+   * @throws {ValidationError} If update data is invalid
+   */
+  updateUser: (id: string, data: UpdateUserData) => Promise<User>
+
+  /**
+   * Deletes a user by their unique identifier
+   *
+   * @param id - The unique identifier of the user to delete
+   * @returns Promise resolving when deletion is complete
+   * @throws {UserNotFoundError} If the user does not exist
+   */
+  deleteUser: (id: string) => Promise<void>
+}
+```
+
+```typescript
+// src/logic/user/user.ts
+import { IBaseComponent, START_COMPONENT, STOP_COMPONENT } from '@well-known-components/interfaces'
+import { IUserComponent } from './types'
+import { UserNotFoundError } from './errors'
+
+/**
+ * Creates the User component
+ *
+ * Orchestrates user management operations:
+ * 1. Validates user data and permissions
+ * 2. Interacts with database for CRUD operations
+ * 3. Logs all user-related activities
+ * 4. Tracks performance metrics for user operations
+ *
+ * @param components Required components: database, logs, metrics
+ * @returns IUserComponent implementation
+ */
+export async function createUserComponent(
+  components: Pick<AppComponents, 'database' | 'logs' | 'metrics'>
+): Promise<IUserComponent> {
+  const { database, logs, metrics } = components
+  const logger = logs.getLogger('user-component')
+
+  return {
+    /**
+     * Retrieves a user by their unique identifier
+     *
+     * This method MUST validate the user exists before returning.
+     * All database queries are logged for audit purposes and tracked with metrics.
+     *
+     * @param id - The unique identifier of the user
+     * @returns The user object if found
+     * @throws {UserNotFoundError} If the user with the given id does not exist
+     */
+    async getUser(id: string): Promise<User> {
+      const timer = metrics.startTimer('user_get_duration')
+      try {
+        logger.debug('Fetching user', { userId: id })
+        const user = await database.query('SELECT * FROM users WHERE id = $1', [id])
+        if (!user) {
+          throw new UserNotFoundError(`User with id ${id} not found`)
+        }
+        return user
+      } finally {
+        timer()
+      }
+    },
+
+    /**
+     * Creates a new user with the provided data
+     *
+     * @param data - User creation data including email and name
+     * @returns The created user object
+     * @throws {ValidationError} If user data is invalid
+     * @throws {DuplicateUserError} If a user with the same email already exists
+     */
+    async createUser(data: CreateUserData): Promise<User> {
+      logger.info('Creating user', { email: data.email })
+      const user = await database.query(
+        'INSERT INTO users (email, name) VALUES ($1, $2) RETURNING *',
+        [data.email, data.name]
+      )
+      return user
+    },
+
+    /**
+     * Updates an existing user with new data
+     *
+     * @param id - The unique identifier of the user to update
+     * @param data - User update data containing fields to modify
+     * @returns The updated user object
+     * @throws {UserNotFoundError} If the user with the given id does not exist
+     */
+    async updateUser(id: string, data: UpdateUserData): Promise<User> {
+      logger.info('Updating user', { userId: id })
+      const user = await database.query(
+        'UPDATE users SET name = $1 WHERE id = $2 RETURNING *',
+        [data.name, id]
+      )
+      if (!user) {
+        throw new UserNotFoundError(`User with id ${id} not found`)
+      }
+      return user
+    },
+
+    /**
+     * Deletes a user by their unique identifier
+     *
+     * @param id - The unique identifier of the user to delete
+     * @throws {UserNotFoundError} If the user with the given id does not exist
+     */
+    async deleteUser(id: string): Promise<void> {
+      logger.info('Deleting user', { userId: id })
+      await database.query('DELETE FROM users WHERE id = $1', [id])
+    }
+  }
+}
+
+// src/logic/user/index.ts
+export { createUserComponent } from './user'
+export type { IUserComponent } from './types'
+```
+
+## Directory Structure Reference
+
+```
+src/
+├── adapters/           # External service integrations
+│   ├── postgres.ts     # PostgreSQL adapter
+│   ├── redis.ts        # Redis adapter
+│   ├── s3.ts           # S3 adapter
+│   └── rpc-server/     # RPC server adapter
+├── logic/              # Business logic components
+│   ├── user/
+│   │   ├── component.ts
+│   │   ├── types.ts
+│   │   └── index.ts
+│   ├── job/
+│   │   ├── component.ts
+│   │   └── index.ts
+│   └── notifications/
+├── controllers/        # Request/response handling
+│   └── handlers/
+│       ├── users.ts
+│       └── health.ts
+├── types/
+│   ├── components.ts   # All component interfaces
+│   └── system.ts       # System-wide types
+├── components.ts       # Main component wiring
+└── docs/
+    └── openapi.yaml    # API documentation
+```
+
+## Error Handling Pattern
+
+```typescript
+/**
+ * Creates the User component with proper error handling
+ *
+ * @param components Required components: database, logs
+ * @returns IUserComponent implementation
+ */
+export async function createUserComponent(
+  components: Pick<AppComponents, 'database' | 'logs'>
+): Promise<IUserComponent> {
+  const { database, logs } = components
+  const logger = logs.getLogger('user-component')
+
+  return {
+    /**
+     * Retrieves a user by their unique identifier
+     *
+     * @param id - The unique identifier of the user
+     * @returns The user object if found
+     * @throws {UserNotFoundError} If the user with the given id does not exist
+     * @throws {DatabaseError} If a database error occurs during the query
+     */
+    async getUser(id: string): Promise<User> {
+      try {
+        const user = await database.query('SELECT * FROM users WHERE id = $1', [id])
+        if (!user) {
+          throw new UserNotFoundError(`User with id ${id} not found`)
+        }
+        return user
+      } catch (error) {
+        logger.error('Error fetching user', { userId: id, error })
+        throw error
+      }
+    }
+  }
+}
+```
+
+## JSDoc Documentation Patterns
+
+### Factory Function Documentation
+
+```typescript
+/**
+ * Creates the Component
+ *
+ * Orchestrates operations:
+ * 1. Step one
+ * 2. Step two
+ * 3. Step three
+ *
+ * @param components Required components: dep1, dep2
+ * @returns IComponent implementation
+ */
+```
+
+### Method Documentation
+
+```typescript
+/**
+ * Brief description of what the method does
+ *
+ * Additional context about behavior, preconditions, or side effects.
+ *
+ * @param paramName - Description of the parameter
+ * @returns Description of the return value
+ * @throws {ErrorType} When this error occurs
+ */
+```
+
+### Complex Method Documentation
+
+```typescript
+/**
+ * Validates operation parameters and prepares result metadata
+ *
+ * This method MUST be called before executing the operation.
+ *
+ * The validation process:
+ * 1. Validates input format and required fields
+ * 2. Checks authorization and permissions
+ * 3. Verifies resource existence and state
+ * 4. Prepares response metadata structure
+ *
+ * @param params - Operation parameters containing identifier and options
+ * @returns Prepared metadata object with validation results
+ * @throws {ValidationError} If input parameters are invalid
+ * @throws {UnauthorizedError} If user lacks required permissions
+ * @throws {NotFoundError} If the referenced resource does not exist
+ */
+```
+
+## Validation Checklist
+
+- [ ] Component extends `IBaseComponent` interface
+- [ ] Factory function follows `create*Component` naming convention
+- [ ] Dependencies declared using `Pick<AppComponents, ...>`
+- [ ] Proper async patterns implemented
+- [ ] Error handling includes logging and typed errors
+- [ ] Lifecycle methods (`START_COMPONENT`, `STOP_COMPONENT`) implemented when needed
+- [ ] Component organized in appropriate directory (`adapters/` or `logic/`)
+- [ ] Interface defined in `types/components.ts`
+- [ ] Single responsibility maintained
+- [ ] Dependencies minimal and non-circular
+- [ ] Resource cleanup handled in stop methods
+- [ ] Factory function has comprehensive JSDoc
+- [ ] All public methods have JSDoc with `@param`, `@returns`, `@throws`
+- [ ] Interface methods have JSDoc documentation
+- [ ] HTTP endpoints documented in `docs/openapi.yaml`

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "f=$(jq -r '.tool_input.file_path // empty'); case \"$f\" in *.env*) echo \"Refusing to edit env file — likely contains secrets.\" >&2; exit 2;; esac"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "f=$(jq -r '.tool_input.file_path // empty'); case \"$f\" in *.ts|*.tsx) npx prettier --write \"$f\" 2>/dev/null;; esac"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/dcl-backend-standards
+++ b/.claude/skills/dcl-backend-standards
@@ -1,0 +1,1 @@
+../../.agents/skills/dcl-backend-standards

--- a/.claude/skills/dcl-testing
+++ b/.claude/skills/dcl-testing
@@ -1,0 +1,1 @@
+../../.agents/skills/dcl-testing

--- a/.claude/skills/dcl-wkc-components
+++ b/.claude/skills/dcl-wkc-components
@@ -1,0 +1,1 @@
+../../.agents/skills/dcl-wkc-components

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,59 @@
+# AI Agent Instructions
+
+## Project Context
+
+See [docs/ai-agent-context.md](docs/ai-agent-context.md) for service architecture, tech stack, key concepts, and API surface.
+
+For broader Decentraland contributor guidelines, see <https://docs.decentraland.org/llms.txt>
+
+## Skills
+
+This project uses skills from [decentraland/ai-toolkit](https://github.com/decentraland/ai-toolkit). Load the relevant skill **before** making changes:
+
+| Skill | When to load |
+|---|---|
+| `dcl-testing` | Writing, modifying, or reviewing `*.spec.ts` / `*.test.ts` files |
+| `dcl-wkc-components` | Working on files in `src/components.ts`, `src/ports/`, `src/logic/`, `src/controllers/`, `src/types/`, or any file importing from `@well-known-components` |
+| `dcl-backend-standards` | Any backend `*.ts` file — type safety, error handling, security, HTTP conventions, logging, env config |
+
+## Hooks
+
+Git hooks are enforced via `simple-git-hooks` + `nano-staged` (configured in `package.json`). New contributors get them auto-installed by the `prepare` script on `npm install`:
+
+- **Pre-commit**: runs `tslint` and `prettier --check` on staged `*.{js,ts}` files via nano-staged.
+- **Pre-push**: runs `npm run typecheck && npm test -- --no-coverage`.
+
+Fix lint issues before committing: `npm run lint:fix`. To temporarily bypass hooks (rare; do not abuse): `SKIP_SIMPLE_GIT_HOOKS=1 git commit ...`.
+
+Claude Code hooks (configured in `.claude/settings.json`, team-wide):
+
+- **PreToolUse** on `Edit|Write`: blocks edits to any `*.env*` path (likely contains secrets).
+- **PostToolUse** on `Edit|Write`: auto-formats edited `.ts` / `.tsx` files via `npx prettier --write`.
+
+## Testing
+
+- **Logic tests** (`test/tests/logic/`): unit tests for individual functions and components in isolation.
+- **Port tests** (`test/tests/ports/`): integration tests for external service integrations and HTTP endpoints.
+- Load the `dcl-testing` skill for full testing standards.
+
+## Development Commands
+
+| Task | Command |
+|---|---|
+| Install dependencies | `npm install` |
+| Type-check only | `npm run typecheck` |
+| Build (type-check + emit) | `npm run build` |
+| Run dev server (watch) | `npm run start:watch` |
+| Run dev server (debug) | `npm run debug` |
+| Run all tests | `npm test` |
+| Run tests in watch mode | `npm run test:watch` |
+| Lint (check) | `npm run lint` |
+| Lint (fix) | `npm run lint:fix` |
+| Run migrations | `npm run migrate` |
+
+## Workflow
+
+- Default branch: **`master`** (not `main`).
+- Branch names: `feat/`, `fix/`, `refactor/`, `chore/`.
+- Commits: Conventional Commits (`feat:`, `fix:`, `refactor:`, `chore:`). **No `Co-Authored-By` line.**
+- PRs: target `master`. CI runs via GitHub Actions in `.github/workflows/` (`node`, `docker`, `deploy`, `release`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,8 +37,10 @@
         "expect": "^26.6.2",
         "fetch-mock": "^9.11.0",
         "jest": "^29.7.0",
+        "nano-staged": "^1.0.2",
         "nodemon": "^2.0.9",
         "prettier": "^2.3.2",
+        "simple-git-hooks": "^2.13.1",
         "ts-jest": "^29.4.6",
         "ts-node": "^9.1.1",
         "tslint": "^6.1.3",
@@ -2344,6 +2346,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -3182,6 +3185,7 @@
       "version": "25.0.0",
       "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-25.0.0.tgz",
       "integrity": "sha512-EtXXmPTgCDdVP7q2/5xkhSUBvVh+3bniH/Z7S5Vq/wdO3jQC5MZJNkvAZRkmgUUoydvp0z7Ur9Zy6zsgrDanqw==",
+      "peer": true,
       "dependencies": {
         "ajv": "^8.11.0",
         "ajv-errors": "^3.0.0",
@@ -3430,6 +3434,7 @@
       "version": "8.19.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
       "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -4335,7 +4340,6 @@
       "integrity": "sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "jest-regex-util": "30.0.1"
@@ -4350,7 +4354,6 @@
       "integrity": "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
@@ -4770,7 +4773,6 @@
       "integrity": "sha512-H9xg1/sfVvyfU7o3zMfBEjQ1gcsdeTMgqHoYdN79tuLqfTtuu7WckRA1R5whDwOzxaZAeMKTYWqP+WCAi0CHsg==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@jest/pattern": "30.0.1",
         "@jest/schemas": "30.0.5",
@@ -4790,7 +4792,6 @@
       "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@sinclair/typebox": "^0.34.0"
       },
@@ -4803,8 +4804,7 @@
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
       "integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/@jest/types/node_modules/@types/yargs": {
       "version": "17.0.35",
@@ -4812,7 +4812,6 @@
       "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@types/yargs-parser": "*"
       }
@@ -4823,7 +4822,6 @@
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -4841,7 +4839,6 @@
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -4852,7 +4849,6 @@
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -4939,6 +4935,7 @@
       "version": "21.5.0",
       "resolved": "https://registry.npmjs.org/@magic-sdk/provider/-/provider-21.5.0.tgz",
       "integrity": "sha512-q2UAww4Hv8qDg+GYUqmUhdLPL5lfmYXpD6HN1IMI1HBU/SG2hLMVs/28u+RrCC1GddrqTTDal9GXONd3OHurHA==",
+      "peer": true,
       "dependencies": {
         "@magic-sdk/types": "^17.3.0",
         "eventemitter3": "^4.0.4",
@@ -4951,7 +4948,8 @@
     "node_modules/@magic-sdk/types": {
       "version": "17.3.0",
       "resolved": "https://registry.npmjs.org/@magic-sdk/types/-/types-17.3.0.tgz",
-      "integrity": "sha512-0mTFr1qDJ94pOJkFu1oZ/s2KnV7lHgILvWuFh7fs7ugyn7z9M7euP9g+Bv+kEdZ6ja4QlNi+UR0OryaXowv75w=="
+      "integrity": "sha512-0mTFr1qDJ94pOJkFu1oZ/s2KnV7lHgILvWuFh7fs7ugyn7z9M7euP9g+Bv+kEdZ6ja4QlNi+UR0OryaXowv75w==",
+      "peer": true
     },
     "node_modules/@metamask/safe-event-emitter": {
       "version": "2.0.0",
@@ -6723,6 +6721,7 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/@well-known-components/http-server/-/http-server-1.1.6.tgz",
       "integrity": "sha512-ufTiLQg1QPrgiDjr3bYuKdevZyLkJONRpmFd922F6Ty+Wd0CCOoZZzyP0vlanr0DvcrTifkO04N33fEuhg0AsQ==",
+      "peer": true,
       "dependencies": {
         "@types/compression": "^1.7.0",
         "@types/cors": "^2.8.9",
@@ -6763,6 +6762,7 @@
       "resolved": "https://registry.npmjs.org/@well-known-components/interfaces/-/interfaces-1.4.3.tgz",
       "integrity": "sha512-roVtoOHG6uaH+nL4C0ISnAwkkopc2FLsS7fqX+roI22EdX9PAknPoImhPU8/3u6jgRAVpglX5Zj4nWZkSaXPkQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@types/node": "^20.3.1",
         "@types/node-fetch": "^2.5.12",
@@ -7251,6 +7251,7 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-26.6.3.tgz",
       "integrity": "sha512-lGS5PXGAzR4RF7V5+XObhqz2KZIDUA1yD0DG6pBVmy10eh0ZIXQImRuzocsI/N2XZ1GrLFwTS27In2i2jlpq1Q==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@jest/core": "^26.6.3",
         "import-local": "^3.0.2",
@@ -7938,6 +7939,7 @@
       "version": "8.12.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -8668,6 +8670,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -8773,6 +8776,7 @@
       "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.8.tgz",
       "integrity": "sha512-4T53u4PdgsXqKaIctwF8ifXlRTTmEPJ8iEPWFdGZvcf7sbwYo6FKFEX9eNNAnzFZ7EzJAQ3CJeOtCRA4rDp7Pw==",
       "hasInstallScript": true,
+      "peer": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
       },
@@ -12128,7 +12132,8 @@
     "node_modules/idb-keyval": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.1.tgz",
-      "integrity": "sha512-8Sb3veuYCyrZL+VBt9LJfZjLUPWVvqn8tG28VqYNFCo43KHcKuq+b4EiXGeuaLAQWL2YmyDgMp2aSpH9JHsEQg=="
+      "integrity": "sha512-8Sb3veuYCyrZL+VBt9LJfZjLUPWVvqn8tG28VqYNFCo43KHcKuq+b4EiXGeuaLAQWL2YmyDgMp2aSpH9JHsEQg==",
+      "peer": true
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -16300,6 +16305,7 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
       "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
+      "peer": true,
       "dependencies": {
         "lie": "3.1.1"
       }
@@ -16353,7 +16359,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "peer": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -16660,6 +16665,19 @@
       "version": "9.9.0",
       "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
       "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
+    },
+    "node_modules/nano-staged": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/nano-staged/-/nano-staged-1.0.2.tgz",
+      "integrity": "sha512-Fytar3zHLY99nlMfqPPbraxZodqQAHPpdPRyYaplL+lB9DCR6pUrafxbG+Btz4+7fO5Rm/+DO4ZeDO/nLSUMhw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "nano-staged": "lib/bin.js"
+      },
+      "engines": {
+        "node": "^22 || >= 24"
+      }
     },
     "node_modules/nanomatch": {
       "version": "1.2.13",
@@ -17524,6 +17542,7 @@
       "version": "8.7.3",
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.7.3.tgz",
       "integrity": "sha512-HPmH4GH4H3AOprDJOazoIcpI49XFsHCe8xlrjHkWiapdbHK+HLtbm/GQzXYAZwmPju/kzKhjaSfMACG+8cgJcw==",
+      "peer": true,
       "dependencies": {
         "buffer-writer": "2.0.0",
         "packet-reader": "1.0.0",
@@ -17784,6 +17803,7 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.2.tgz",
       "integrity": "sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==",
       "dev": true,
+      "peer": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -19106,6 +19126,17 @@
         "simple-concat": "^1.0.0"
       }
     },
+    "node_modules/simple-git-hooks": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/simple-git-hooks/-/simple-git-hooks-2.13.1.tgz",
+      "integrity": "sha512-WszCLXwT4h2k1ufIXAgsbiTOazqqevFCIncOuUBZJ91DdvWcC5+OFkluWRQPrcuSYd8fjq+o2y1QfWqYMoAToQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "simple-git-hooks": "cli.js"
+      }
+    },
     "node_modules/sinon": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-10.0.0.tgz",
@@ -20124,6 +20155,7 @@
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
       "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "arg": "^4.1.0",
         "create-require": "^1.1.0",
@@ -20156,6 +20188,7 @@
       "integrity": "sha512-IbR4nkT96EQOvKE2PW/djGz8iGNeJ4rF2mBfiYaR/nvUWYKJhLwimoJKgjIFEIDibBtOevj7BqCRL4oHeWWUCg==",
       "deprecated": "TSLint has been deprecated in favor of ESLint. Please see https://github.com/palantir/tslint/issues/4534 for more information.",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "builtin-modules": "^1.1.1",
@@ -20334,6 +20367,7 @@
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
       "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -20777,6 +20811,7 @@
       "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
       "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
       "hasInstallScript": true,
+      "peer": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
       },
@@ -20896,6 +20931,7 @@
           "url": "https://github.com/sponsors/wevm"
         }
       ],
+      "peer": true,
       "dependencies": {
         "@noble/curves": "1.9.1",
         "@noble/hashes": "1.8.0",
@@ -21325,6 +21361,7 @@
       "version": "7.5.5",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.5.tgz",
       "integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w==",
+      "peer": true,
       "engines": {
         "node": ">=8.3.0"
       },
@@ -22856,6 +22893,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -23532,6 +23570,7 @@
       "version": "25.0.0",
       "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-25.0.0.tgz",
       "integrity": "sha512-EtXXmPTgCDdVP7q2/5xkhSUBvVh+3bniH/Z7S5Vq/wdO3jQC5MZJNkvAZRkmgUUoydvp0z7Ur9Zy6zsgrDanqw==",
+      "peer": true,
       "requires": {
         "ajv": "^8.11.0",
         "ajv-errors": "^3.0.0",
@@ -23675,6 +23714,7 @@
           "version": "8.19.0",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
           "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+          "peer": true,
           "requires": {}
         }
       }
@@ -24381,7 +24421,6 @@
       "integrity": "sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "requires": {
         "@types/node": "*",
         "jest-regex-util": "30.0.1"
@@ -24392,8 +24431,7 @@
           "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.0.1.tgz",
           "integrity": "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==",
           "dev": true,
-          "optional": true,
-          "peer": true
+          "optional": true
         }
       }
     },
@@ -24725,7 +24763,6 @@
       "integrity": "sha512-H9xg1/sfVvyfU7o3zMfBEjQ1gcsdeTMgqHoYdN79tuLqfTtuu7WckRA1R5whDwOzxaZAeMKTYWqP+WCAi0CHsg==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "requires": {
         "@jest/pattern": "30.0.1",
         "@jest/schemas": "30.0.5",
@@ -24742,7 +24779,6 @@
           "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
           "dev": true,
           "optional": true,
-          "peer": true,
           "requires": {
             "@sinclair/typebox": "^0.34.0"
           }
@@ -24752,8 +24788,7 @@
           "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
           "integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==",
           "dev": true,
-          "optional": true,
-          "peer": true
+          "optional": true
         },
         "@types/yargs": {
           "version": "17.0.35",
@@ -24761,7 +24796,6 @@
           "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
           "dev": true,
           "optional": true,
-          "peer": true,
           "requires": {
             "@types/yargs-parser": "*"
           }
@@ -24772,7 +24806,6 @@
           "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "optional": true,
-          "peer": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -24783,8 +24816,7 @@
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true,
-          "optional": true,
-          "peer": true
+          "optional": true
         },
         "supports-color": {
           "version": "7.2.0",
@@ -24792,7 +24824,6 @@
           "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "optional": true,
-          "peer": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -24872,6 +24903,7 @@
       "version": "21.5.0",
       "resolved": "https://registry.npmjs.org/@magic-sdk/provider/-/provider-21.5.0.tgz",
       "integrity": "sha512-q2UAww4Hv8qDg+GYUqmUhdLPL5lfmYXpD6HN1IMI1HBU/SG2hLMVs/28u+RrCC1GddrqTTDal9GXONd3OHurHA==",
+      "peer": true,
       "requires": {
         "@magic-sdk/types": "^17.3.0",
         "eventemitter3": "^4.0.4",
@@ -24881,7 +24913,8 @@
     "@magic-sdk/types": {
       "version": "17.3.0",
       "resolved": "https://registry.npmjs.org/@magic-sdk/types/-/types-17.3.0.tgz",
-      "integrity": "sha512-0mTFr1qDJ94pOJkFu1oZ/s2KnV7lHgILvWuFh7fs7ugyn7z9M7euP9g+Bv+kEdZ6ja4QlNi+UR0OryaXowv75w=="
+      "integrity": "sha512-0mTFr1qDJ94pOJkFu1oZ/s2KnV7lHgILvWuFh7fs7ugyn7z9M7euP9g+Bv+kEdZ6ja4QlNi+UR0OryaXowv75w==",
+      "peer": true
     },
     "@metamask/safe-event-emitter": {
       "version": "2.0.0",
@@ -26354,6 +26387,7 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/@well-known-components/http-server/-/http-server-1.1.6.tgz",
       "integrity": "sha512-ufTiLQg1QPrgiDjr3bYuKdevZyLkJONRpmFd922F6Ty+Wd0CCOoZZzyP0vlanr0DvcrTifkO04N33fEuhg0AsQ==",
+      "peer": true,
       "requires": {
         "@types/compression": "^1.7.0",
         "@types/cors": "^2.8.9",
@@ -26389,6 +26423,7 @@
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/@well-known-components/interfaces/-/interfaces-1.4.3.tgz",
       "integrity": "sha512-roVtoOHG6uaH+nL4C0ISnAwkkopc2FLsS7fqX+roI22EdX9PAknPoImhPU8/3u6jgRAVpglX5Zj4nWZkSaXPkQ==",
+      "peer": true,
       "requires": {
         "@types/node": "^20.3.1",
         "@types/node-fetch": "^2.5.12",
@@ -26770,6 +26805,7 @@
           "resolved": "https://registry.npmjs.org/jest/-/jest-26.6.3.tgz",
           "integrity": "sha512-lGS5PXGAzR4RF7V5+XObhqz2KZIDUA1yD0DG6pBVmy10eh0ZIXQImRuzocsI/N2XZ1GrLFwTS27In2i2jlpq1Q==",
           "dev": true,
+          "peer": true,
           "requires": {
             "@jest/core": "^26.6.3",
             "import-local": "^3.0.2",
@@ -27289,6 +27325,7 @@
       "version": "8.12.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "peer": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -27851,6 +27888,7 @@
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
       "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -27929,6 +27967,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.8.tgz",
       "integrity": "sha512-4T53u4PdgsXqKaIctwF8ifXlRTTmEPJ8iEPWFdGZvcf7sbwYo6FKFEX9eNNAnzFZ7EzJAQ3CJeOtCRA4rDp7Pw==",
+      "peer": true,
       "requires": {
         "node-gyp-build": "^4.3.0"
       }
@@ -30439,7 +30478,8 @@
     "idb-keyval": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.1.tgz",
-      "integrity": "sha512-8Sb3veuYCyrZL+VBt9LJfZjLUPWVvqn8tG28VqYNFCo43KHcKuq+b4EiXGeuaLAQWL2YmyDgMp2aSpH9JHsEQg=="
+      "integrity": "sha512-8Sb3veuYCyrZL+VBt9LJfZjLUPWVvqn8tG28VqYNFCo43KHcKuq+b4EiXGeuaLAQWL2YmyDgMp2aSpH9JHsEQg==",
+      "peer": true
     },
     "ieee754": {
       "version": "1.2.1",
@@ -33618,6 +33658,7 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
       "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
+      "peer": true,
       "requires": {
         "lie": "3.1.1"
       }
@@ -33667,7 +33708,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "peer": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
@@ -33913,6 +33953,12 @@
       "version": "9.9.0",
       "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
       "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
+    },
+    "nano-staged": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/nano-staged/-/nano-staged-1.0.2.tgz",
+      "integrity": "sha512-Fytar3zHLY99nlMfqPPbraxZodqQAHPpdPRyYaplL+lB9DCR6pUrafxbG+Btz4+7fO5Rm/+DO4ZeDO/nLSUMhw==",
+      "dev": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -34577,6 +34623,7 @@
       "version": "8.7.3",
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.7.3.tgz",
       "integrity": "sha512-HPmH4GH4H3AOprDJOazoIcpI49XFsHCe8xlrjHkWiapdbHK+HLtbm/GQzXYAZwmPju/kzKhjaSfMACG+8cgJcw==",
+      "peer": true,
       "requires": {
         "buffer-writer": "2.0.0",
         "packet-reader": "1.0.0",
@@ -34769,7 +34816,8 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.2.tgz",
       "integrity": "sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "pretty-format": {
       "version": "26.6.2",
@@ -35780,6 +35828,12 @@
         "simple-concat": "^1.0.0"
       }
     },
+    "simple-git-hooks": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/simple-git-hooks/-/simple-git-hooks-2.13.1.tgz",
+      "integrity": "sha512-WszCLXwT4h2k1ufIXAgsbiTOazqqevFCIncOuUBZJ91DdvWcC5+OFkluWRQPrcuSYd8fjq+o2y1QfWqYMoAToQ==",
+      "dev": true
+    },
     "sinon": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-10.0.0.tgz",
@@ -36551,6 +36605,7 @@
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
       "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
       "dev": true,
+      "peer": true,
       "requires": {
         "arg": "^4.1.0",
         "create-require": "^1.1.0",
@@ -36570,6 +36625,7 @@
       "resolved": "https://registry.npmjs.org/tslint/-/tslint-6.1.3.tgz",
       "integrity": "sha512-IbR4nkT96EQOvKE2PW/djGz8iGNeJ4rF2mBfiYaR/nvUWYKJhLwimoJKgjIFEIDibBtOevj7BqCRL4oHeWWUCg==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "builtin-modules": "^1.1.1",
@@ -36704,7 +36760,8 @@
     "typescript": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw=="
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "peer": true
     },
     "ufo": {
       "version": "1.5.3",
@@ -37006,6 +37063,7 @@
       "version": "5.0.10",
       "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
       "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "peer": true,
       "requires": {
         "node-gyp-build": "^4.3.0"
       }
@@ -37086,6 +37144,7 @@
       "version": "2.46.3",
       "resolved": "https://registry.npmjs.org/viem/-/viem-2.46.3.tgz",
       "integrity": "sha512-2LJS+Hyh2sYjHXQtzfv1kU9pZx9dxFzvoU/ZKIcn0FNtOU0HQuIICuYdWtUDFHaGXbAdVo8J1eCvmjkL9JVGwg==",
+      "peer": true,
       "requires": {
         "@noble/curves": "1.9.1",
         "@noble/hashes": "1.8.0",
@@ -37431,6 +37490,7 @@
       "version": "7.5.5",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.5.tgz",
       "integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w==",
+      "peer": true,
       "requires": {}
     },
     "xdg-basedir": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "lint": "tslint -p tsconfig.json",
     "lint:fix": "tslint -p tsconfig.json --fix",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
     "build": "tsc -p tsconfig.json",
     "watch:build": "tsc -p tsconfig.json --watch",
     "start": "npm run build && node --abort-on-uncaught-exception --unhandled-rejections=strict dist/index.js",
@@ -13,7 +14,18 @@
     "start:watch": "nodemon src/index.ts",
     "test": "jest --forceExit --detectOpenHandles --coverage --verbose",
     "test:watch": "jest --watch --verbose",
-    "migrate": "node-pg-migrate --database-url-var PG_COMPONENT_PSQL_CONNECTION_STRING --envPath .env -j ts --tsconfig tsconfig.json -m ./src/migrations"
+    "migrate": "node-pg-migrate --database-url-var PG_COMPONENT_PSQL_CONNECTION_STRING --envPath .env -j ts --tsconfig tsconfig.json -m ./src/migrations",
+    "prepare": "simple-git-hooks"
+  },
+  "simple-git-hooks": {
+    "pre-commit": "npx nano-staged",
+    "pre-push": "npm run typecheck && npm test -- --no-coverage"
+  },
+  "nano-staged": {
+    "*.{js,ts}": [
+      "tslint",
+      "prettier --check"
+    ]
   },
   "keywords": [
     "decentraland"
@@ -54,8 +66,10 @@
     "expect": "^26.6.2",
     "fetch-mock": "^9.11.0",
     "jest": "^29.7.0",
+    "nano-staged": "^1.0.2",
     "nodemon": "^2.0.9",
     "prettier": "^2.3.2",
+    "simple-git-hooks": "^2.13.1",
     "ts-jest": "^29.4.6",
     "ts-node": "^9.1.1",
     "tslint": "^6.1.3",

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,20 @@
+{
+  "version": 1,
+  "skills": {
+    "dcl-backend-standards": {
+      "source": "decentraland/ai-toolkit",
+      "sourceType": "github",
+      "computedHash": "21156cdc0fa1e645e24f47cb873f5abb74f0c8bb6313871e9efd93151093e5b8"
+    },
+    "dcl-testing": {
+      "source": "decentraland/ai-toolkit",
+      "sourceType": "github",
+      "computedHash": "a172a9acb50dd656325623648a5281f56eb6aef6fe295b5e5c944752ecaea175"
+    },
+    "dcl-wkc-components": {
+      "source": "decentraland/ai-toolkit",
+      "sourceType": "github",
+      "computedHash": "d6fbac079ab680cfe2b1128f52f0b4c651cd53a5c18620a6a99fc6d8865473ff"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds **AGENTS.md** following the team template, with **CLAUDE.md** as a pointer (`@AGENTS.md`) so a single source of truth covers every agent tool.
- Imports the Decentraland AI-toolkit skills (`dcl-testing`, `dcl-wkc-components`, `dcl-backend-standards`) under `.agents/skills/`, surfaced via symlinks in `.claude/skills/`, version-pinned via `skills-lock.json`.
- Adds `.claude/settings.json` with team-wide Claude Code hooks: PreToolUse blocks edits to `*.env*` paths; PostToolUse auto-formats `.ts` / `.tsx` edits via `npx prettier --write`.
- Adds `simple-git-hooks` + `nano-staged` for pre-commit (`tslint` + `prettier --check` on staged `*.{js,ts}`) and pre-push (`npm run typecheck && npm test -- --no-coverage`). Auto-installs via the `prepare` script.

## Test plan

- [ ] `npm install` auto-runs the `prepare` script and writes `.git/hooks/pre-commit` and `pre-push`.
- [ ] `git commit` with a modified `*.ts` file triggers nano-staged → tslint + prettier --check.
- [ ] `git push` triggers `npm run typecheck && npm test -- --no-coverage`.
- [ ] Open the repo in Claude Code: AGENTS.md is loaded, the three `dcl-*` skills are listed, the two hooks fire on Edit/Write.
- [ ] Editing a `.env*` file via Claude is blocked with the "likely contains secrets" message.
- [ ] Editing a `.ts` file via Claude auto-runs prettier in the background.